### PR TITLE
Restrict BCI images to <15.5 while in beta

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,10 +36,8 @@
       "groupName": "kustomize"
     },
     {
-      "matchManagers": ["dockerfile", "helm-values"],
-      "matchPackagePatterns": ["registry.suse.com/"],
-      "matchUpdateTypes": ["patch", "pin", "digest"],
-      "schedule": ["every weekend after 4am"]
+      "matchPackagePatterns": ["registry.suse.com/bci/bci"],
+      "allowedVersions": "<15.5.0"
     },
     {
       "matchPackagePatterns": ["rancher/dapper"],


### PR DESCRIPTION
- Adds a restriction for `bci/bci` images (so not the language images) to avoid creating PRs for 15.5 while it is in beta
