### PR TITLE
Add support for KUBECTL_VERSION env var

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,12 @@
   "regexManagers": [
     {
       "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile[^/]*$"],
+      "matchStrings": ["ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile[^/]*$"],
       "matchStrings": ["ENV KUSTOMIZE_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"],
       "depNameTemplate": "kubernetes-sigs/kustomize",
       "datasourceTemplate": "github-releases"
@@ -66,6 +72,10 @@
     {
       "matchPackagePatterns": ["derailed/k9s"],
       "schedule": ["every weekend after 4am"]
+    },
+    {
+      "matchDepNames": ["kubernetes/kubernetes"],
+      "allowedVersions": "<1.26.0"
     }
   ]
 }


### PR DESCRIPTION
- Enables support for updating `ENV KUBECTL_VERSION` in Dockerfiles
- Adds restriction to `kubernetes/kubernetes` to be lower than 1.26.0