### PR TITLE
Add support updating rancher/kubectl in Helm chart

### DIFF
--- a/default.json
+++ b/default.json
@@ -33,6 +33,16 @@
       "matchStrings": [".*?https:\/\/raw.githubusercontent.com\/golangci\/golangci-lint\/master\/install.sh.*?sh -s (?<currentValue>.*?);"],
       "depNameTemplate": "golangci/golangci-lint",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "fileMatch": [
+        "values.yaml$"
+      ],
+      "matchStrings": [
+        "global:[\\s\\S]*?kubectl:[\\s\\S]*?repository:\\s(?<depName>.*?)\\n[\\s\\S]*?tag:\\s(?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "docker",
+      "description": "usage of rancher/kubectl in global.kubectl in Helm chart"
     }
   ],
   "packageRules": [
@@ -55,8 +65,13 @@
       "pinDigests": true
     },
     {
-      "matchDepNames": ["kubernetes/kubernetes"],
+      "matchPackagePatterns": ["kubernetes/kubernetes"],
       "allowedVersions": "<1.26.0"
+    },
+    {
+      "matchPackagePatterns": ["rancher/kubectl"],
+      "allowedVersions": "<1.25.0",
+      "description": "kubectl is supported within one minor version (older or newer) of kube-apiserver"
     }
   ]
 }


### PR DESCRIPTION
This will add support for common usage of `rancher/kubectl` in Helm chart, see example below:

```
global:
  cattle:
    systemDefaultRegistry: ""
  kubectl:
    repository: rancher/kubectl
    tag: v1.21.9
```