### PR TITLE
Updated renovatebot/github-action with new config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,8 +43,10 @@ jobs:
           installation_id: ${{ secrets.RENOVATE_INSTALLATION_ID }}
           private_key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@24c7a5d0372c64ae42b6b02f155a4223f5ea6a8d # v35.1.2
+        uses: renovatebot/github-action@2529763aa12e6d5b445bc911e8bd8cce2a4f205c # v36.0.1
         env:
+          # Specify what Renovate version to use (this is separate from the github-action version)
+          RENOVATE_VERSION: "35.8.3"
           # Repository taken from variable to keep configuration file generic
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # Onboarding not needed for self hosted
@@ -60,5 +62,6 @@ jobs:
           # Override loglevel if set
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
         with:
+          renovate-version: ${{ env.RENOVATE_VERSION }}
           configurationFile: .github/renovate.json
           token: '${{ steps.get_token.outputs.token }}'

--- a/default.json
+++ b/default.json
@@ -5,6 +5,12 @@
   "automergeStrategy": "merge-commit",
   "regexManagers": [
     {
+      "fileMatch": ["\\.github/workflows/renovate.yml"],
+      "matchStrings": [".*?RENOVATE_VERSION:\\s(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "renovate/renovate",
+      "datasourceTemplate": "docker"
+    },
+    {
       "fileMatch": ["(^|/|\\.)Dockerfile$", "(^|/)Dockerfile[^/]*$"],
       "matchStrings": ["ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"],
       "depNameTemplate": "kubernetes/kubernetes",
@@ -46,6 +52,10 @@
     }
   ],
   "packageRules": [
+    {
+      "matchPackagePatterns": ["renovate/renovate"],
+      "extractVersion": "(?<version>.*)-slim$"
+    },
     {
       "matchPackagePatterns": ["kustomize"],
       "extractVersion": "^kustomize\/(?<version>.*)$",


### PR DESCRIPTION
From https://github.com/renovatebot/github-action/releases/tag/v36.0.0:

```
This action no longer follows renovate versions, use [renovate-version](https://github.com/renovatebot/github-action#renovate-version) to pin the renovate version.
```

This changes the way the version is set, it configures environment variable `RENOVATE_VERSION` to be used with the action. The action version will be updated as usual, using built-in Renovate logic as we used to do before this change.

The environment variable however, now needs to be updated using a regex. And I started by using renovate releases (https://github.com/renovatebot/renovate/releases) as source for the version but it seems that the `$VERSION-slim` might be delayed and not available. That would result in an updated version but no available `-slim` image. So I changed the source to Docker Hub and a version modifier to only check `-slim` versions. Depending if we keep using `-slim`, we can strip this but for now its a reliable way to get the latest available version with `-slim` image available.

If you don't set `renovate-version`, it will default to latest which I don't like to do. This means that they control what version we use by releasing a new version and we no longer benefit from our `main` -> `release` process.