### PR TITLE
No restriction on amount of PRs that can be open

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
     "dependencies"
   ],
   "automergeStrategy": "merge-commit",
+  "prConcurrentLimit": 0,
   "constraints": {
     "go": "1.19"
   },


### PR DESCRIPTION
By default, only 10 PRs can be open at the same time. No new PRs will be opened if this limit is reached which is annoying and can be confusing. `0` disables the limit.

Ref: https://docs.renovatebot.com/configuration-options/#prconcurrentlimit