### PR TITLE
Update rancher/helm version based on branch name

### DIFF
--- a/default.json
+++ b/default.json
@@ -81,6 +81,18 @@
     },
     {
       "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile[^/]*$"
+      ],
+      "matchStrings": [
+        "RUN git -C / clone --branch release-(?<currentValue>.*?) --depth=1 https://github.com/rancher/helm\\n"
+      ],
+      "depNameTemplate": "rancher/helm",
+      "packageNameTemplate": "https://github.com/rancher/helm",
+      "datasourceTemplate": "git-refs"
+    },
+    {
+      "fileMatch": [
         "values.yaml$"
       ],
       "matchStrings": [
@@ -183,6 +195,12 @@
         "patch"
       ],
       "pinDigests": true
+    },
+    {
+      "matchPackagePatterns": [
+        "rancher/helm"
+      ],
+      "extractVersion": "^release-(?<version>.*)$"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
- Automatically updates `rancher/helm` references based on branch names in GitHub repository using `git-refs` datasource