### PR TITLE
Need to split datasource and pkg for Golang

### DIFF
--- a/default.json
+++ b/default.json
@@ -183,12 +183,15 @@
       "matchPackagePatterns": [
         "registry.suse.com/bci/golang"
       ],
-      "matchDatasources": [
-        "golang-version"
-      ],
       "matchPackageNames": [
         "golang",
         "go"
+      ],
+      "allowedVersions": "<1.20.0"
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
       ],
       "allowedVersions": "<1.20.0"
     },


### PR DESCRIPTION
It will match both basically and as the packages are not from that datasource, it won't match. Solution is to break the two sources apart.