### PR TITLE
rebaseWhen=auto is recommended with automerge

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "baseBranches": [
     "main"
   ],
-  "rebaseWhen": "conflicted",
+  "rebaseWhen": "auto",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
According to https://docs.renovatebot.com/configuration-options/#rebasewhen:

```
rebaseWhen=conflicted is not recommended if you have enabled Renovate automerge
```

Although we do not have automerge enabled by default, some repositories might enable it and `auto` takes care of both situations in the best way.