### PR TITLE
Avoid error if there are no changes for release PR

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -16,6 +16,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
       - name: Create PR
-        run: gh pr create --title "Release week $(date +%V)" --body "Automatically created PR to merge main into release" --base release --head main
+        run: |
+          PR=$(gh pr create --title "Release week $(date +%V)" --body "Automatically created PR to merge main into release" --base release --head main)
+          RETVAL=$?
+          if [ "${RETVAL}" -ne 0 ]; then
+              echo "Error while creating pull request, error: ${PR}" >> $GITHUB_STEP_SUMMARY
+          else
+              echo "Created pull request: ${PR}" >> $GITHUB_STEP_SUMMARY
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is to avoid https://github.com/rancher/renovate-config/actions/runs/4552885808/jobs/8028784369