### PR TITLE
Auto merge renovate non-major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,12 @@
       "automerge": true,
       "pinDigests": true,
       "schedule": ["every weekend after 4am"]
+    },
+    {
+      "matchPackageNames": ["renovate/renovate"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "schedule": ["every weekend after 4am"]
     }
   ]
 }


### PR DESCRIPTION
As the GitHub Actions was split up in an action version and an environment variable that defines the actual Renovate version, we need to add a rule to auto merge the non major Renovate updates.