### PR TITLE
Revert to using k8s 1.25.x go modules

### DIFF
--- a/default.json
+++ b/default.json
@@ -173,7 +173,7 @@
         "k8s.io/sample-controller"
       ],
       "groupName": "gomod-k8sio-dependencies",
-      "allowedVersions": "<0.27.0"
+      "allowedVersions": "<0.26.0"
     },
     {
       "matchPackagePatterns": [
@@ -224,7 +224,7 @@
       "matchPackagePatterns": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.27.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
From https://github.com/rancher/rancher/issues/41113#issue-1660591947:

```
So for kubernetes 1.26 support it is decided that the k8s libraries will be kept at 1.25.x version only.
```