### PR TITLE
Add k3d patching

### DIFF
--- a/default.json
+++ b/default.json
@@ -299,6 +299,17 @@
       ],
       "allowedVersions": "<1.28.0",
       "description": "kubectl is supported within one minor version (older or newer) of kube-apiserver"
+    },    
+    {
+      "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile[^/]*$"
+      ],
+      "matchStrings": [
+        "K3D_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"
+      ],
+      "depNameTemplate": "k3d-io/k3d",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
k3d is currently used for [testing cis-operator](https://github.com/rancher/cis-operator/blob/758346a7d1a5cc5b81a83f76146cf7d974ceed9b/Dockerfile.dapper#L6C5-L6C16).