### PR TITLE
Add k3d patching

### DIFF
--- a/default.json
+++ b/default.json
@@ -179,6 +179,17 @@
       ],
       "datasourceTemplate": "docker",
       "description": "usage of rancher/kubectl in global.kubectl in Helm chart"
+    },    
+    {
+      "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile[^/]*$"
+      ],
+      "matchStrings": [
+        "K3D_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"
+      ],
+      "depNameTemplate": "k3d-io/k3d",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
k3d is currently used in [rancher](https://github.com/rancher/rancher/blob/release/v2.8/Dockerfile.dapper#L13) and for [testing cis-operator](https://github.com/rancher/cis-operator/blob/758346a7d1a5cc5b81a83f76146cf7d974ceed9b/Dockerfile.dapper#L6C5-L6C16).