### PR TITLE
Support for Go 1.22

### DIFF
--- a/default.json
+++ b/default.json
@@ -301,13 +301,13 @@
         "golang",
         "go"
       ],
-      "allowedVersions": "<1.22.0"
+      "allowedVersions": "<1.23.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.22.0"
+      "allowedVersions": "<1.23.0"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Enable bumps to the recently released [Go 1.22](https://tip.golang.org/doc/go1.22).