### PR TITLE
Add support for checksum bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,7 +34,9 @@
       ],
       "matchStrings": [
         "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n",
-        "ARG KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"
+        "ARG KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n",
+        "KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n",
+        "KUBECTL_VERSION_amd64(\\=|\\s)(?<currentDigest>.*?)\\n"        
       ],
       "depNameTemplate": "kubernetes/kubernetes",
       "datasourceTemplate": "github-releases"
@@ -223,6 +225,19 @@
       ],
       "depNameTemplate": "k3d-io/k3d",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/|\\.)Dockerfile$",
+        "(^|/)Dockerfile[^/]*$",
+        "(^|/)Makefile$",
+        "hack/make/deps.mk"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_(version|VERSION).*=(\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*=(\\s|\"|)(?<currentDigest>.*)(\"|)"
+      ]
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Fixes #206.

Examples of usage:

```
# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench
KUBE_BENCH_VERSION=v0.7.0
# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.7.0
KUBE_BENCH_SUM_arm64=53da250a3211d717378e6ef37ee541d2cd212953628b064f2f7e2ca8a5a7bb57
# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.7.0
KUBE_BENCH_SUM_amd64=e9ede7c6f3570cf8f4e81925cd2523fc9c3442fb8304477637f231c7b4647e7d


# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy
SONOBUOY_VERSION ?= v0.57.0
# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy digestVersion=v0.57.0
SONOBUOY_SUM_arm64 ?= "75c6f1d590ade2de2fbe59d53ff8005ff99d31517f2f12a6a36a03573f7e73c3"
# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy digestVersion=v0.57.0
SONOBUOY_SUM_amd64 ?= f9006ed997fd5a701b34a96786efffa52d5e77873bfc717bc252c2e5ef8a7f3c
```