### PR TITLE
Correct tibdex/github-app-token parameters to fix warnings

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -17,7 +17,8 @@ jobs:
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.RENOVATE_APP_ID }}
-          installation_id: ${{ secrets.RENOVATE_INSTALLATION_ID }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.RENOVATE_INSTALLATION_ID }}
           private_key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -40,7 +40,8 @@ jobs:
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.RENOVATE_APP_ID }}
-          installation_id: ${{ secrets.RENOVATE_INSTALLATION_ID }}
+          installation_retrieval_mode: id
+          installation_retrieval_payload: ${{ secrets.RENOVATE_INSTALLATION_ID }}
           private_key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@7d358366277001f3316d7fa54ff49a81c0158948 # v40.1.7


### PR DESCRIPTION
This PR should fix https://github.com/rancher/renovate-config/issues/253 and update parameters per the actions current docs for the version we are using.

Worth noting - the output of the current action config does claim it is a success. See here:
```
Run tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
  with:
    app_id: ***
    installation_id: ***
    private_key: ***
  
    github_api_url: https://api.github.com/
    installation_retrieval_mode: repository
    installation_retrieval_payload: rancher/backup-restore-operator
    revoke: true
Token created successfully
```

However it appears to be using a different "installation_retrieval_mode" than how we were using it before 2.x. So if that's working correctly then another solution to this would be simply removing the `installation_id` parameter instead of correcting the syntax like with this PR here.