### PR TITLE
Consolidate KUBECTL version handling

### DIFF
--- a/default.json
+++ b/default.json
@@ -36,10 +36,7 @@
         "(^|/)Dockerfile[^/]*$"
       ],
       "matchStrings": [
-        "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n",
-        "ARG KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n",
-        "KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n",
-        "KUBECTL_VERSION_amd64(\\=|\\s)(?<currentDigest>.*?)\\n"        
+        "KUBECTL_VERSION.*\\=\\s*(?<currentValue>.*?)\\n"
       ],
       "depNameTemplate": "kubernetes/kubernetes",
       "datasourceTemplate": "github-releases"

--- a/default.json
+++ b/default.json
@@ -33,7 +33,8 @@
       "customType": "regex",
       "fileMatch": [
         "(^|/|\\.)Dockerfile$",
-        "(^|/)Dockerfile[^/]*$"
+        "(^|/)Dockerfile[^/]*$",
+        "hack/make/deps.mk"
       ],
       "matchStrings": [
         "KUBECTL_VERSION.*\\=\\s*(?<currentValue>.*?)\\n"


### PR DESCRIPTION
The existing regexes were removed and consolidated onto a single one which cover more use cases. Example matches:

```Dockerfile
ENV KUBECTL_VERSION = 1.28.1
ARG KUBECTL_VERSION = 1.28.2
KUBECTL_VERSION = 1.28.3
KUBECTL_VERSION ?= 1.28.4
```

This PR also expands this specific match on `deps.mk`. Note that for the majority of cases #243 should suffice for that file, hence the expansion to this matches only.