### PR TITLE
Revert Renovate version

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -41,7 +41,7 @@ concurrency: renovate
 
 env:
   # Specify what Renovate version to use (this is separate from the github-action version)
-  RENOVATE_VERSION: "37.385.5"
+  RENOVATE_VERSION: "37.385.0"
   # Repository taken from variable to keep configuration file generic
   RENOVATE_REPOSITORIES: ${{ github.repository }}
   # Onboarding not needed for self hosted


### PR DESCRIPTION
Version `37.385.5` isn't actually available, as there is no such tag in [renovatebot/renovate#37.385.5](https://github.com/renovatebot/renovate/releases/tag/37.385.5) and pipelines are failing ([example](https://github.com/rancher/webhook/actions/runs/9412800339/job/25928324459#step:2:19)), because they can't find such image.

Let's revert back to [renovatebot/renovate#37.385.0](https://github.com/renovatebot/renovate/releases/tag/37.385.0) and then let Renovate auto-update itself later.

This fix continues in https://github.com/rancher/renovate-config/pull/297.