### PR TITLE
Fix renovate-deploy.yml

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -11,13 +11,25 @@ permissions: {}
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    outputs:
+      owner: ${{ steps.set_values.outputs.owner }}
+      repositories: ${{ steps.set_values.outputs.repositories }}
     steps:
+      - name: Set owner and repositories values
+        id: set_values
+        run: | 
+          owner=$(echo "${{ github.event.inputs.deployRepository }}" | cut -d '/' -f1)
+          repositories=$(echo "${{ github.event.inputs.deployRepository }}" | cut -d '/' -f2)
+          echo "owner=$owner" >> "$GITHUB_OUTPUT"
+          echo "repositories=$repositories" >> "$GITHUB_OUTPUT"
       - name: Get token
         id: get_token
         uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          owner: ${{ steps.set_values.outputs.owner }}
+          repositories: ${{ steps.set_values.outputs.repositories }}
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:


### PR DESCRIPTION
This PR will address the issue with the `renovate-deploy` workflow. 

Changes:
- Add output parameters used to split the user input when triggering the workflow
- Add `owner` and `repositories` parameters for scoping the GH_TOKEN access only to the repository provided.