### PR TITLE
Add support for generating Renovate with Vault PRs

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -52,8 +52,12 @@ jobs:
           mkdir -p .github/workflows
           TEMP_CONFIG=$(mktemp)
           jq --arg default_branch "${DEFAULT_BRANCH}" '.baseBranches = [$default_branch]' ../main/files/renovate.json > "${TEMP_CONFIG}"
-          mv "${TEMP_CONFIG}" .github/renovate.json
-          git add .github/renovate.json
+          
+          if [ ! -f .github/renovate.json ]; then
+            mv "${TEMP_CONFIG}" .github/renovate.json
+            git add .github/renovate.json
+          fi
+
           cp ../main/files/renovate-vault.yml .github/workflows/renovate-vault.yml
           git add .github/workflows/renovate-vault.yml
           FILES_TO_REMOVE=".github/dependabot.yaml .github/dependabot.yml .github/workflows/renovate.yml"

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -16,9 +16,13 @@ on:
   schedule:
     - cron: '30 4,6 * * *'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate.yml@release
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@release
     with:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}


### PR DESCRIPTION
Now that a new renovate workflow for Vault exists, update the deployment workflow to use it instead of the existing.