### PR TITLE
build: Fix self-renovate workflow

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -1,4 +1,5 @@
-name: Renovate
+# The renovate workflow_call, for remote repositories to call.
+name: Renovate (Vault)
 on:
   workflow_call:
     inputs:
@@ -34,8 +35,6 @@ on:
         required: false
         default: '["ubuntu-latest"]'
         type: string
-  schedule:
-    - cron: '30 4,6 * * 6,0'
 
 concurrency: renovate
 
@@ -64,7 +63,7 @@ permissions:
 
 jobs:
   renovate:
-    runs-on: ${{fromJSON(inputs.runner)}}
+    runs-on: ${{ inputs.runner || 'staging' }}
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,4 +1,6 @@
-name: Renovate
+# This workflow is deprecated, and will be removed once
+# all callers across the ecosystem moves on to renovate-vault.yml.
+name: Renovate (deprecated)
 on:
   workflow_call:
     inputs:
@@ -34,8 +36,6 @@ on:
         required: false
         default: '["ubuntu-latest"]'
         type: string
-  schedule:
-    - cron: '30 4,6 * * 6,0'
 
 concurrency: renovate
 
@@ -78,4 +78,3 @@ jobs:
           renovate-version: ${{ env.RENOVATE_VERSION }}
           configurationFile: ${{ env.RENOVATE_CONFIG_FILE }}
           token: "${{ steps.get_token.outputs.token }}"
-

--- a/.github/workflows/self-renovate.yml
+++ b/.github/workflows/self-renovate.yml
@@ -1,0 +1,30 @@
+# Runs renovate for this repository.
+name: Renovate
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Override default log level"
+        required: false
+        default: "info"
+        type: string
+      overrideSchedule:
+        description: "Override all schedules"
+        required: false
+        default: "false"
+        type: string
+
+  schedule:
+    - cron: '30 4,6 * * 6,0'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  call-workflow:
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@release
+    with:
+      logLevel: ${{ inputs.logLevel || 'info' }}
+      overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
+    secrets: inherit


### PR DESCRIPTION
Make it explicit what workflows are workflow_calls and the one that is not, and meant to be used for the renovate execution for this specific repository.

This fixes the issues that renovate runs had on this repository.