### PR TITLE
Bump Kubernetes and Go versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -300,7 +300,7 @@
         "k8s.io/sample-controller"
       ],
       "groupName": "gomod-k8sio-dependencies",
-      "allowedVersions": "<0.28.0"
+      "allowedVersions": "<0.32.0"
     },
     {
       "matchPackagePatterns": [
@@ -351,13 +351,13 @@
       "matchPackagePatterns": [
         "kubernetes/kubernetes"
       ],
-      "allowedVersions": "<1.28.0"
+      "allowedVersions": "<1.32.0"
     },
     {
       "matchPackagePatterns": [
         "rancher/kubectl"
       ],
-      "allowedVersions": "<1.28.0",
+      "allowedVersions": "<1.32.0",
       "description": "kubectl is supported within one minor version (older or newer) of kube-apiserver"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -9,7 +9,7 @@
   "automergeStrategy": "merge-commit",
   "prConcurrentLimit": 0,
   "constraints": {
-    "go": "<1.24"
+    "go": "<1.25"
   },
   "postUpdateOptions": [
     "gomodTidy"
@@ -317,13 +317,13 @@
         "golang",
         "go"
       ],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Enable bumps to Go to `v1.24` and Kubernetes to `v1.31`.