### PR TITLE
Add support for config migration PRs

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: '["ubuntu-latest"]'
         type: string
+      configMigration:
+        description: "Toggle PRs for config migration"
+        required: false
+        default: "true"
+        type: string
   workflow_dispatch:
     inputs:
       logLevel:
@@ -34,6 +39,11 @@ on:
         description: "Value to be used on runs-on"
         required: false
         default: '["ubuntu-latest"]'
+        type: string
+      configMigration:
+        description: "Toggle PRs for config migration"
+        required: false
+        default: "true"
         type: string
 
 concurrency: renovate
@@ -56,6 +66,8 @@ env:
   # Override loglevel if set
   LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
   RENOVATE_CONFIG_FILE: .github/renovate.json
+  # https://docs.renovatebot.com/configuration-options/#configmigration
+  RENOVATE_CONFIG_MIGRATION: ${{ inputs.configMigration || 'true' }}
 
 permissions:
   contents: read

--- a/.github/workflows/self-renovate.yml
+++ b/.github/workflows/self-renovate.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "false"
         type: string
+      configMigration:
+        description: "Toggle PRs for config migration"
+        required: false
+        default: "true"
+        type: string
 
   schedule:
     - cron: '30 4,6 * * 6,0'
@@ -25,6 +30,7 @@ jobs:
   call-workflow:
     uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@release
     with:
+      configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
     secrets: inherit

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: "false"
         type: string
+      configMigration:
+        description: "Toggle PRs for config migration"
+        required: false
+        default: "true"
+        type: string
   # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
   schedule:
     - cron: '30 4,6 * * *'
@@ -24,6 +29,7 @@ jobs:
   call-workflow:
     uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@release
     with:
+      configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
     secrets: inherit


### PR DESCRIPTION
Renovate has the ability to propose PRs for migrating Renovate PRs. This is important so that projects are able to keep up with latest Renovate format, avoiding surprises of sudden deprecated settings.

Upstream documentation: https://docs.renovatebot.com/configuration-options/#configmigration

This setting is now enabled by default and can be overridden on a pipeline-trigger-basis.

Closes #383.