### PR TITLE
Add support for custom renovate config

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: "true"
         type: string
+      renovateConfig:
+        description: "Define a custom renovate config file"
+        required: false
+        default: ".github/renovate.json"
+        type: string
   workflow_dispatch:
     inputs:
       logLevel:
@@ -65,7 +70,7 @@ env:
   RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
   # Override loglevel if set
   LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
-  RENOVATE_CONFIG_FILE: .github/renovate.json
+  RENOVATE_CONFIG_FILE: ${{ inputs.renovateConfig || '.github/renovate.json' }}
   # https://docs.renovatebot.com/configuration-options/#configmigration
   RENOVATE_CONFIG_MIGRATION: ${{ inputs.configMigration || 'true' }}
 


### PR DESCRIPTION
Some repositories have the need to have different configurations depending on whether they are targeting the development branch, or release/backporting branches.

This new input enables users to change the renovate config during execution.