### PR TITLE
Fix logic for golangci-lint using `?=`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TMP_DIR := $(realpath build/tmp)
+TMP_DIR := $(shell mkdir -p build/tmp && realpath build/tmp)
 RENOVATE_IMG := renovate/renovate:slim
 
 VALIDATE_FILE := docker run --rm -v $(shell pwd):/repo:ro -e LOG_LEVEL=debug \

--- a/default.json
+++ b/default.json
@@ -112,7 +112,7 @@
       ],
       "matchStrings": [
         ".*?https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh.*?sh -s (?<currentValue>.*?);",
-        "GOLANGCI_(LINT|LINT_VER|VERSION)(\\=|:\\=|\\?\\=|\\s)(?<currentValue>.*?)\\n"
+        "GOLANGCI_(LINT|LINT_VER|VERSION)(:|\\?|\\s)*=\\s*(?<currentValue>.*?)\\n"
       ],
       "depNameTemplate": "golangci/golangci-lint",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
The range of tested permutations for `golangci-lint` that works with these changes:
```Makefile
GOLANGCI_VERSION ?= v1.64.1
GOLANGCI_VERSION := v1.64.1
GOLANGCI_VERSION = v1.64.1
GOLANGCI_VERSION=v1.64.1
```