### PR TITLE
Handle Go major bumps and group GitHub Actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -332,6 +332,21 @@
       "allowedVersions": "<1.0.0"
     },
     {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "actions/**",
+        "github/codeql-action/**"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "pinDigests": true
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],

--- a/default.json
+++ b/default.json
@@ -350,9 +350,13 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchPackageNames": [
+        "!actions/**",
+        "!github/codeql-action/**"
+      ],
       "matchUpdateTypes": [
-        "minor",
-        "patch"
+        "major",
+        "minor"
       ],
       "pinDigests": true
     },

--- a/default.json
+++ b/default.json
@@ -12,7 +12,8 @@
     "go": "<1.25"
   },
   "postUpdateOptions": [
-    "gomodTidy"
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ],
   "customManagers": [
     {


### PR DESCRIPTION
As part of these changes, digest bumps for GitHub Actions will be dropped - to decrease renovate noise. Note that digest pin will still be in place, however will only take place for `minor` and `major` bumps.

Relates to #391 #272.