### PR TITLE
Adjust to allow input branch for easier debugging

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ".github/renovate.json"
         type: string
+      branch:
+        description: "The target branch, used to checkout renovate config"
+        required: false
+        default: ""
+        type: "string"
   workflow_dispatch:
     inputs:
       logLevel:
@@ -50,6 +55,11 @@ on:
         required: false
         default: "true"
         type: string
+      branch:
+        description: "The target branch, used to checkout renovate config"
+        required: false
+        default: ""
+        type: "string"
 
 concurrency: renovate
 
@@ -84,6 +94,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.branch || github.ref_name }}
       - name: Validate and printout config
         run: jq -e . "${RENOVATE_CONFIG_FILE}"
       - name: Load Secrets from Vault


### PR DESCRIPTION
This should allow project owners to more easily test their renovate config changes.

Essentially this can allow them to make a new branch (push to rancher repo, not their fork) and then manually trigger renovate with a specific branches `renovate.json` intended to be used for that run. This can allow for a PR to be created and tested w/o being merged and give more direct feedback on what Renovate PRs that will create/close/modify/etc.

I've intentionally not updated `files/renovate-vault.yaml` as I wasn't sure that one should be updated, or a new one added for projects to use during debugging. Since it may not be desirable to have that branch input exposed by default.