### PR TITLE
Group all GHA updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -336,28 +336,6 @@
       "matchManagers": [
         "github-actions"
       ],
-      "matchPackageNames": [
-        "actions/**",
-        "github/codeql-action/**"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "pinDigests": true
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchPackageNames": [
-        "!actions/**",
-        "!github/codeql-action/**"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
       "pinDigests": true
     },
     {


### PR DESCRIPTION
Context: https://github.com/rancher/rancher/issues/49411#issuecomment-2715893802

I see grouping was recently added for a subset of github actions. I'm adding a few more which should benefit the org.

I'm also tempted to add the full list of "allowed github actions"

Thoughts? @pjbgf / @mallardduck