### PR TITLE
Bump renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TMP_DIR := $(shell mkdir -p build/tmp && realpath build/tmp)
-RENOVATE_IMG := renovate/renovate:slim
+RENOVATE_IMG := renovate/renovate:full
 
 VALIDATE_FILE := docker run --rm -v $(shell pwd):/repo:ro -e LOG_LEVEL=debug \
 		$(RENOVATE_IMG) renovate-config-validator --strict

--- a/default.json
+++ b/default.json
@@ -19,7 +19,8 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "\\.github/workflows/renovate.yml"
+        "\\.github/workflows/renovate.yml",
+        "\\.github/workflows/renovate-vault.yml"
       ],
       "matchStrings": [
         ".*?RENOVATE_VERSION:\\s\\\"(?<currentValue>.*?)\\\"\\n"
@@ -246,7 +247,8 @@
       "matchPackagePatterns": [
         "renovate/renovate"
       ],
-      "extractVersion": "(?<version>.*)-slim$"
+      "extractVersion": "(?<version>.*)-full$",
+      "groupName": "renovate-bumps"
     },
     {
       "matchPackagePatterns": [

--- a/default.json
+++ b/default.json
@@ -244,27 +244,27 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
-        "renovate/renovate"
+      "matchPackageNames": [
+        "/renovate/renovate/"
       ],
       "extractVersion": "(?<version>.*)-full$",
       "groupName": "renovate-bumps"
     },
     {
-      "matchPackagePatterns": [
-        "kustomize"
-      ],
       "extractVersion": "^kustomize/(?<version>.*)$",
-      "groupName": "kustomize"
+      "groupName": "kustomize",
+      "matchPackageNames": [
+        "/kustomize/"
+      ]
     },
     {
       "matchManagers": [
         "gomod"
       ],
-      "matchPackagePatterns": [
-        "^sigs.k8s.io"
-      ],
-      "groupName": "gomod-sigsk8sio-dependencies"
+      "groupName": "gomod-sigsk8sio-dependencies",
+      "matchPackageNames": [
+        "/^sigs.k8s.io/"
+      ]
     },
     {
       "matchManagers": [
@@ -305,19 +305,17 @@
       "allowedVersions": "<0.32.0"
     },
     {
-      "matchPackagePatterns": [
-        "registry.suse.com/bci/bci",
-        "registry.suse.com/suse/sle15"
-      ],
-      "allowedVersions": "<15.7.0"
+      "allowedVersions": "<15.7.0",
+      "matchPackageNames": [
+        "/registry.suse.com/bci/bci/",
+        "/registry.suse.com/suse/sle15/"
+      ]
     },
     {
-      "matchPackagePatterns": [
-        "registry.suse.com/bci/golang"
-      ],
       "matchPackageNames": [
         "golang",
-        "go"
+        "go",
+        "/registry.suse.com/bci/golang/"
       ],
       "allowedVersions": "<1.25.0"
     },
@@ -328,10 +326,10 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "matchPackagePatterns": [
-        "rancher/dapper"
-      ],
-      "allowedVersions": "<1.0.0"
+      "allowedVersions": "<1.0.0",
+      "matchPackageNames": [
+        "/rancher/dapper/"
+      ]
     },
     {
       "groupName": "GitHub Actions",
@@ -363,23 +361,23 @@
       "pinDigests": true
     },
     {
-      "matchPackagePatterns": [
-        "rancher/helm"
-      ],
-      "extractVersion": "^release-(?<version>.*)$"
+      "extractVersion": "^release-(?<version>.*)$",
+      "matchPackageNames": [
+        "/rancher/helm/"
+      ]
     },
     {
-      "matchPackagePatterns": [
-        "kubernetes/kubernetes"
-      ],
-      "allowedVersions": "<1.32.0"
-    },
-    {
-      "matchPackagePatterns": [
-        "rancher/kubectl"
-      ],
       "allowedVersions": "<1.32.0",
-      "description": "kubectl is supported within one minor version (older or newer) of kube-apiserver"
+      "matchPackageNames": [
+        "/kubernetes/kubernetes/"
+      ]
+    },
+    {
+      "allowedVersions": "<1.32.0",
+      "description": "kubectl is supported within one minor version (older or newer) of kube-apiserver",
+      "matchPackageNames": [
+        "/rancher/kubectl/"
+      ]
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
The upstream Renovate project stopped tagging slim releases [last year](https://hub.docker.com/r/renovate/renovate/tags?name=-slim), which resulted in our Renovate configuration no longer identifying new releases.

xref: https://docs.renovatebot.com/release-notes-for-major-versions/#our-docker-images-are-slim-by-default