### PR TITLE
Add config for `rancher/kuberlr-kubectl`

### DIFF
--- a/default.json
+++ b/default.json
@@ -366,6 +366,16 @@
         "patch",
         "digest"
       ]
+    },
+    {
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -369,13 +369,7 @@
     },
     {
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
-      "matchPackageNames": ["rancher/kuberlr-kubectl"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "enabled": true
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
This rule helps to cover the new `rancher/kuberlr-kubectl` image my team maintains. This project uses 1 major version for each Rancher Minor version. As such, this PR aims to ensure that when Renovate bumps this for our teams it will only propose the valid Minor/Patch bumps and skips Majors.