### PR TITLE
Change renovate schedules for this repository

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,9 +11,7 @@
     },
     {
       "matchPackageNames": ["renovate/renovate"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "schedule": ["every weekend after 4am"]
+      "schedule": ["* * * * 2"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,8 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
       "pinDigests": true,
-      "schedule": ["every weekend after 4am"]
+      "schedule": ["* 4 * * 1/2"]
     },
     {
       "matchPackageNames": ["renovate/renovate"],

--- a/.github/workflows/self-renovate.yml
+++ b/.github/workflows/self-renovate.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
   schedule:
-    - cron: '30 4,6 * * 6,0'
+    - cron: '30 4,6 * * 1-5'
 
 permissions:
   contents: read


### PR DESCRIPTION
Changes summary:
- Restrict schedule to weekdays only.
- Disable auto-merge for all dependencies.
- Restrict GH bumps to Mondays fortnightly.
- Restrict Renovate version bumps to Tuesdays (as the release PR only happens on Wednesdays).


Note that all changes are related to the execution of Renovate against this repository. 