### PR TITLE
Rancher Manager presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "baseBranches": ["main"],
   "packageRules": [

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the centralized Renovate preset (`default.json`) and th
 ## Dependency bump alignment across Rancher Manager
 
 For easier alignment of versions across projects around the Rancher Manager
-ecosystem, a few presets were created that enforce version contraints for each
+ecosystem, a few presets were created that enforce version constraints for each
 Rancher minor version.
 
 The presets are available at the root of this repository and follow the naming

--- a/README.md
+++ b/README.md
@@ -7,6 +7,38 @@ This repository contains the centralized Renovate preset (`default.json`) and th
 - `main` (aka develop), this is where the development happens and changes are introduced. This branch is kept up-to-date with Renovate pointing to its own preset.
 - `release`, this is the branch where all the repositories point to. After testing our changes in `main`, we promote `main` to `release`.
 
+## Dependency bump alignment across Rancher Manager
+
+For easier alignment of versions across projects around the Rancher Manager
+ecosystem, a few presets were created that enforce version contraints for each
+Rancher minor version.
+
+The presets are available at the root of this repository and follow the naming
+convention: `rancher-<version>.json`. To use these presets, a project can configure
+their `renovate.json` as per below:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>rancher/renovate-config//rancher-main#rancher-presets"
+  ],
+  "baseBranches": [
+    "main"
+  ],
+  "packageRules": [
+    {
+      "matchBaseBranches": ["releases/v0.7.x"],
+      "extends": ["github>rancher/renovate-config//rancher-2.11#rancher-presets"]
+    },
+    {
+      "matchBaseBranches": ["releases/v0.6.x"],
+      "extends": ["github>rancher/renovate-config//rancher-2.10#rancher-presets"]
+    }
+  ]
+}
+```
+
 ## Testing new changes
 
 Renovate configuration is not very unit testing friendly. Therefore, this project aims to validate all renovate files for syntax issues via `make validate` at its PR checks.

--- a/default.json
+++ b/default.json
@@ -245,7 +245,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "/renovate/renovate/"
+        "renovate/renovate"
       ],
       "extractVersion": "(?<version>.*)-full$",
       "groupName": "renovate-bumps"
@@ -263,7 +263,7 @@
       ],
       "groupName": "gomod-sigsk8sio-dependencies",
       "matchPackageNames": [
-        "/^sigs.k8s.io/"
+        "sigs.k8s.io/**"
       ]
     },
     {
@@ -271,51 +271,33 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "k8s.io/api",
-        "k8s.io/apiextensions-apiserver",
-        "k8s.io/apimachinery",
-        "k8s.io/apiserver",
-        "k8s.io/client-go",
-        "k8s.io/cli-runtime",
-        "k8s.io/cloud-provider",
-        "k8s.io/cluster-bootstrap",
-        "k8s.io/code-generator",
-        "k8s.io/component-base",
-        "k8s.io/component-helpers",
-        "k8s.io/controller-manager",
-        "k8s.io/cri-api",
-        "k8s.io/csi-translation-lib",
-        "k8s.io/kube-aggregator",
-        "k8s.io/kube-controller-manager",
-        "k8s.io/kube-openapi",
-        "k8s.io/kube-proxy",
-        "k8s.io/kube-scheduler",
-        "k8s.io/kubectl",
-        "k8s.io/kubelet",
-        "k8s.io/kubernetes",
-        "k8s.io/legacy-cloud-providers",
-        "k8s.io/metrics",
-        "k8s.io/mount-utils",
-        "k8s.io/pod-security-admission",
-        "k8s.io/sample-apiserver",
-        "k8s.io/sample-cli-plugin",
-        "k8s.io/sample-controller"
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
       ],
       "groupName": "gomod-k8sio-dependencies",
       "allowedVersions": "<0.32.0"
     },
     {
+      "matchPackageNames": [
+        "k8s.io/kubernetes",
+        "kubernetes/kubernetes",
+        "rancher/kubectl"
+      ],
+      "allowedVersions": "<1.32.0"
+    },
+    {
       "allowedVersions": "<15.7.0",
       "matchPackageNames": [
-        "/registry.suse.com/bci/bci/",
-        "/registry.suse.com/suse/sle15/"
+        "/^registry.suse.com/bci/bci/",
+        "/^registry.suse.com/suse/sle15/"
       ]
     },
     {
       "matchPackageNames": [
         "golang",
         "go",
-        "/registry.suse.com/bci/golang/"
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
       ],
       "allowedVersions": "<1.25.0"
     },
@@ -328,7 +310,7 @@
     {
       "allowedVersions": "<1.0.0",
       "matchPackageNames": [
-        "/rancher/dapper/"
+        "rancher/dapper"
       ]
     },
     {
@@ -346,8 +328,8 @@
     },
     {
       "matchPackageNames": [
-        "/^registry.suse.com/",
-        "/^registry.opensuse.org/"
+        "registry.suse.com/**",
+        "registry.opensuse.org/**"
       ],
       "matchCurrentValue": "latest",
       "enabled": false
@@ -366,20 +348,7 @@
     {
       "extractVersion": "^release-(?<version>.*)$",
       "matchPackageNames": [
-        "/rancher/helm/"
-      ]
-    },
-    {
-      "allowedVersions": "<1.32.0",
-      "matchPackageNames": [
-        "/kubernetes/kubernetes/"
-      ]
-    },
-    {
-      "allowedVersions": "<1.32.0",
-      "description": "kubectl is supported within one minor version (older or newer) of kube-apiserver",
-      "matchPackageNames": [
-        "/rancher/kubectl/"
+        "rancher/helm"
       ]
     },
     {
@@ -387,10 +356,7 @@
         "golang.org/x/crypto/x509roots/fallback",
         "golang.org/x/exp"
       ],
-      "matchUpdateTypes": [
-        "patch",
-        "digest"
-      ]
+      "matchUpdateTypes": ["patch","digest"]
     },
     {
       "matchPackageNames": ["rancher/kuberlr-kubectl"],

--- a/default.json
+++ b/default.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": [
     "main"
   ],

--- a/default.json
+++ b/default.json
@@ -336,7 +336,32 @@
       "matchManagers": [
         "github-actions"
       ],
+      "matchDatasources": [
+        "github-tags"
+      ],
+      "matchDepTypes": [
+        "action"
+      ],
       "pinDigests": true
+    },
+    {
+      "matchPackageNames": [
+        "/^registry.suse.com/",
+        "/^registry.opensuse.org/"
+      ],
+      "matchCurrentValue": "latest",
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "matchCurrentValue": "1.24",
+      "enabled": false
     },
     {
       "extractVersion": "^release-(?<version>.*)$",

--- a/files/renovate.json
+++ b/files/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "baseBranches": ["main"],
   "prHourlyLimit": 2

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -1,0 +1,41 @@
+{
+  "extends": ["github>rancher/renovate-config#release"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "allowedVersions": "<1.23.0"
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "allowedVersions": "<1.23.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
+      "allowedVersions": "<1.32.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.32.0"
+    }
+  ]
+}

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -1,0 +1,41 @@
+{
+  "extends": ["github>rancher/renovate-config#release"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "allowedVersions": "<1.24.0"
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "allowedVersions": "<1.24.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
+      "allowedVersions": "<1.33.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.33.0"
+    }
+  ]
+}

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -1,0 +1,41 @@
+{
+  "extends": ["github>rancher/renovate-config#release"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "allowedVersions": "<1.23.0"
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "allowedVersions": "<1.23.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
+      "allowedVersions": "<1.31.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.31.0"
+    }
+  ]
+}

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -1,0 +1,41 @@
+{
+  "extends": ["github>rancher/renovate-config#release"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "allowedVersions": "<1.24.0"
+    },
+    {
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "allowedVersions": "<1.24.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
+      "allowedVersions": "<1.33.0"
+    },
+    {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.33.0"
+    }
+  ]
+}


### PR DESCRIPTION
Simplifies the core renovate configuration, which is then used as base for the creation of [Renovate presets](https://docs.renovatebot.com/config-presets/) for Rancher Manager specific minors. This should decrease the barrier of entry for projects to keep their dependencies aligned with RM with the least amount of effort.

#### How can this be tested?

Downstream repositories would need to modify their Renovate configuration which is slightly different than the one provided in the docs - as these changes are not yet in `main` nor `release`. The configuration would look like the following:

```
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "github>rancher/renovate-config//rancher-main#rancher-presets"
  ],
  "baseBranches": [
    "main"
  ],
  "packageRules": [
    {
      "matchBaseBranches": ["releases/v0.7"],
      "extends": ["github>rancher/renovate-config//rancher-2.11#rancher-presets"]
    },
    {
      "matchBaseBranches": ["releases/v0.6"],
      "extends": ["github>rancher/renovate-config//rancher-2.10#rancher-presets"]
    }
  ]
}
```

Closes https://github.com/rancher/renovate-config/issues/256.

:warning: Not to be merged before #413.