### PR TITLE
Add rule to disable major bumps in release branches

### DIFF
--- a/default.json
+++ b/default.json
@@ -360,7 +360,10 @@
       "matchUpdateTypes": ["patch","digest"]
     },
     {
-      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "description": "Disable major bumps",
+      "matchPackageNames": [
+        "rancher/kuberlr-kubectl"
+      ],
       "matchUpdateTypes": ["minor", "patch"]
     }
   ]

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -37,6 +37,13 @@
         "k8s.io/**"
       ],
       "allowedVersions": "<0.32.0"
+    },
+    {
+      "description": "Disable major bumps",
+      "matchPackageNames": [
+        "rancher/kuberlr-kubectl"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -37,6 +37,13 @@
         "k8s.io/**"
       ],
       "allowedVersions": "<0.33.0"
+    },
+    {
+      "description": "Disable major bumps",
+      "matchPackageNames": [
+        "rancher/kuberlr-kubectl"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -37,6 +37,13 @@
         "k8s.io/**"
       ],
       "allowedVersions": "<0.31.0"
+    },
+    {
+      "description": "Disable major bumps",
+      "matchPackageNames": [
+        "rancher/kuberlr-kubectl"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
Add a new rule that disable automated major bumps in release branches. This is kept in the default ruleset, however this will be removed once projects move on to depend on the Rancher presets.

Currently only rancher/kuberlr-kubectl is part of this rule, however this should be expanded as we identify other packages that should follow the same rule.

cc: @mallardduck 