### PR TITLE
Improve user experience on workflow dispatches and enable use from forks

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -28,28 +28,6 @@ on:
         required: false
         default: ".github/renovate.json"
         type: string
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: "Override default log level"
-        required: false
-        default: "info"
-        type: string
-      overrideSchedule:
-        description: "Override all schedules"
-        required: false
-        default: "false"
-        type: string
-      runner:
-        description: "Value to be used on runs-on"
-        required: false
-        default: '["ubuntu-latest"]'
-        type: string
-      configMigration:
-        description: "Toggle PRs for config migration"
-        required: false
-        default: "true"
-        type: string
 
 concurrency: renovate
 

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -28,6 +28,10 @@ on:
         required: false
         default: ".github/renovate.json"
         type: string
+    secrets:
+      override-token:
+        description: "Overrides the GH App Token. Use this to run from forks which don't have access to the GH App."
+        required: false
 
 concurrency: renovate
 
@@ -64,13 +68,26 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Validate and printout config
         run: jq -e . "${RENOVATE_CONFIG_FILE}"
+      - name: Check token
+        id: override
+        run: |
+          if [[ -n "${{ secrets.override-token }}" ]]; then
+            echo "Override token will be used"
+            echo "use-gh-app=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "GitHub App will be used"
+            echo "use-gh-app=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Load Secrets from Vault
+        if: steps.override.outputs.use-gh-app == 'true'
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
             secret/data/github/org/${{ github.repository_owner }}/github/renovate-rancher appId | APP_ID ;
             secret/data/github/org/${{ github.repository_owner }}/github/renovate-rancher privateKey | PRIVATE_KEY
       - name: Get token
+        if: steps.override.outputs.use-gh-app == 'true'
         id: get_token
         uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
         with:
@@ -81,4 +98,4 @@ jobs:
         with:
           renovate-version: ${{ env.RENOVATE_VERSION }}
           configurationFile: ${{ env.RENOVATE_CONFIG_FILE }}
-          token: "${{ steps.get_token.outputs.token }}"
+          token: "${{ steps.override.outputs.use-gh-app == 'false' && secrets.override-token || steps.get_token.outputs.token }}"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,25 +1,8 @@
 # This workflow is deprecated, and will be removed once
-# all callers across the ecosystem moves on to renovate-vault.yml.
+# all callers across the ecosystem move on to renovate-vault.yml.
 name: Renovate (deprecated)
 on:
   workflow_call:
-    inputs:
-      logLevel:
-        description: "Override default log level"
-        required: false
-        default: "info"
-        type: string
-      overrideSchedule:
-        description: "Override all schedules"
-        required: false
-        default: "false"
-        type: string
-      runner:
-        description: "Value to be used on runs-on"
-        required: false
-        default: '["ubuntu-latest"]'
-        type: string
-  workflow_dispatch:
     inputs:
       logLevel:
         description: "Override default log level"

--- a/.github/workflows/self-renovate.yml
+++ b/.github/workflows/self-renovate.yml
@@ -6,17 +6,36 @@ on:
       logLevel:
         description: "Override default log level"
         required: false
-        default: "info"
-        type: string
+        default: info
+        type: choice
+        options:
+          - info
+          - debug
       overrideSchedule:
         description: "Override all schedules"
         required: false
         default: "false"
-        type: string
+        type: choice
+        options:
+          - "false"
+          - "true"
       configMigration:
         description: "Toggle PRs for config migration"
         required: false
         default: "true"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      runner:
+        description: "Value to be used on runs-on"
+        required: false
+        default: '["ubuntu-latest"]'
+        type: string
+      renovateConfig:
+        description: "Define a custom renovate config file"
+        required: false
+        default: ".github/renovate.json"
         type: string
 
   schedule:

--- a/.github/workflows/self-renovate.yml
+++ b/.github/workflows/self-renovate.yml
@@ -52,4 +52,6 @@ jobs:
       configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
-    secrets: inherit
+      renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
+    secrets:
+      override-token: "${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}"

--- a/README.md
+++ b/README.md
@@ -110,4 +110,11 @@ To understand the final config, check the section `DEBUG: Post-massage config`
 of the logs - this is only visible when renovate is executed in
 debug mode as per above.
 
+#### Running on Forks
+The execution in forks is possible by creating the secret `RENOVATE_FORK_GH_TOKEN`
+in the fork repository, then triggering the Renovate workflow.
+This provides the best way to test E2E scenarios, so that you can
+manipulate dependency versions across the different branches in
+the fork.
+
 [changelogs]: https://docs.renovatebot.com/getting-started/running/#githubcom-token-for-changelogs

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -5,21 +5,35 @@ on:
       logLevel:
         description: "Override default log level"
         required: false
-        default: "info"
-        type: string
+        default: info
+        type: choice
+        options:
+          - info
+          - debug
       overrideSchedule:
         description: "Override all schedules"
         required: false
         default: "false"
-        type: string
+        type: choice
+        options:
+          - "false"
+          - "true"
       configMigration:
         description: "Toggle PRs for config migration"
         required: false
         default: "true"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      renovateConfig:
+        description: "Define a custom renovate config file"
+        required: false
+        default: ".github/renovate.json"
         type: string
-  # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
+
   schedule:
-    - cron: '30 4,6 * * *'
+    - cron: '30 4,6 * * 1-5'
 
 permissions:
   contents: read
@@ -32,4 +46,5 @@ jobs:
       configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
+      renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
     secrets: inherit

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -47,4 +47,5 @@ jobs:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
       renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
-    secrets: inherit
+    secrets:
+      override-token: "${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}"


### PR DESCRIPTION
The main change in UX is the replacement of free-text to `choices`:
![image](https://github.com/user-attachments/assets/cdfc62c9-02c1-455e-adec-80fb7488e018)
Which is now looking like this:
![image](https://github.com/user-attachments/assets/b840be04-d46f-40bf-9a20-a12721dcf41b)

Execution from forks is now enabled without requiring code changes, in order to make it easier for E2E tests.

Closes #418.