### PR TITLE
Add support for custom data sources

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -93,6 +93,8 @@ jobs:
         with:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
+      - name: Generate custom data sources
+        run: hack/generate-data-sources.sh
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@08ed9fa83e24bfe6222557f9e221395c57972127 # v41.0.16
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /tests
+/data

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ validate: # validates (strict mode) all renovate files for syntax errors.
 	$(VALIDATE_FILE) /repo/default.json
 
 test: # this is to enable manual tests, not for CI.
-	@rm -rf $(TMP_DIR) && mkdir -p tests && cp -r tests $(TMP_DIR) && \
-		mkdir -p $(TMP_DIR)/.github && cp default.json $(TMP_DIR)/.github/renovate.json
+	@rm -rf $(TMP_DIR) && mkdir -p tests && cp -r tests $(TMP_DIR)
+	@mkdir -p data && cp -r data $(TMP_DIR)
+	@mkdir -p $(TMP_DIR)/.github && cp default.json $(TMP_DIR)/.github/renovate.json
 	$(TEST_FILE)

--- a/default.json
+++ b/default.json
@@ -16,6 +16,12 @@
     "gomodTidy",
     "gomodUpdateImportPaths"
   ],
+  "customDatasources": {
+    "local": {
+      "defaultRegistryUrlTemplate": "file://data/{{packageName}}.json",
+      "format": "json"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -238,9 +244,21 @@
         "hack/make/deps.mk"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_(version|VERSION).*=(\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*=(\\s|\"|)(?<currentValue>.*)(\"|)",
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*=(\\s|\"|)(?<currentDigest>.*)(\"|)"
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)Makefile$",
+        "hack/make/deps.mk"
+      ],
+      "matchStrings": [
+        "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*=(\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*=(\\s|\"|)(?<currentDigest>.*)(\"|)"
+      ],
+      "datasourceTemplate": "custom.local"
     }
   ],
   "packageRules": [
@@ -250,13 +268,6 @@
       ],
       "extractVersion": "(?<version>.*)-full$",
       "groupName": "renovate-bumps"
-    },
-    {
-      "extractVersion": "^kustomize/(?<version>.*)$",
-      "groupName": "kustomize",
-      "matchPackageNames": [
-        "/kustomize/"
-      ]
     },
     {
       "matchManagers": [

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -exo pipefail
+
+DATA_DIR="data"
+
+kustomize_fetch_data() {
+    curl -L https://api.github.com/repos/kubernetes-sigs/kustomize/releases | \
+    jq -r '.[].assets[] | select(.name == "checksums.txt") | .browser_download_url' | \
+    head -n3 | xargs -I{} curl -L {} >> "${DATA_DIR}/kustomize-data.raw"
+}
+
+kustomize_save_arch_sources() {
+    archs=("amd64" "arm64" "s390x")
+
+    for arch in "${archs[@]}"; do
+          grep "linux_${arch}" kustomize-data.raw | jq -n --raw-input --slurp '{ "releases": [
+            inputs | split("\n")[]
+            | select(test("^\\w+\\s+kustomize_"))
+            | match("(?<digest>\\w+)\\s+kustomize_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")
+            | { version: ("\(.captures[1].string)"), digest: .captures[0].string }
+          ]}' > "${DATA_DIR}/kustomize-${arch}.json"
+    done
+}
+
+main() {
+    mkdir -p "${DATA_DIR}"
+    kustomize_fetch_data
+    kustomize_save_arch_sources
+}
+
+main


### PR DESCRIPTION
Dependencies that have Go-module tags (e.g. `module/<version>`), may lead to challenges when trying to bump versions and their digests. This issue was raised [upstream] to no avail.

Some of the side effects is that when Renovate attempts to reach out to the github-release-attachments data source, instead of using the full version (e.g. `kustomize/v1.1.1`), it only uses the semver part of the tag, resulting in it not being able to find the binaries for said version.

The proposed solution has two components: a generic [custom] data source that is file-based, and a script that is executed pre-execution to generate the data source files.

A new syntax has been introduced:
```Makefile
# renovate-local: <DATA-SOURCE-FILE>
```

Which also supports digests:
```Makefile
# renovate-local: <DATA-SOURCE-FILE>=<VERSION>
<VAR_NAME>_SUM_<ARCH> := <DIGEST>
```

Due to the inner workings of Renovate, the data source file needs to be a combination of the dependency and its archicteture. But the new syntax is flexible enough to support any additional complexity (e.g. OS info).

For Kustomize, this would look like the below:
```Makefile
# renovate-local: kustomize-amd64
KUSTOMIZE_VERSION := v5.5.0
# renovate-local: kustomize-arm64=v5.5.0
KUSTOMIZE_SUM_arm64 := b4170d1acb8cfacace9f72884bef957ff56efdcd4813b66e7604aabc8b57e93d
# renovate-local: kustomize-amd64=v5.5.0
KUSTOMIZE_SUM_amd64 := 6703a3a70a0c47cf0b37694030b54f1175a9dfeb17b3818b623ed58b9dbc2a77
# renovate-local: kustomize-s390x=v5.5.0
KUSTOMIZE_SUM_s390x := 37dcd2429ef93886319b39671071b2e1c5307993cdb6a5c097cfefc97177d296
```

Closes #367.

[custom]: https://docs.renovatebot.com/modules/datasource/custom/
[upstream]: https://github.com/renovatebot/renovate/discussions/28446