### PR TITLE
Clone custom data source script

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -66,6 +66,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: rancher/renovate-config
+          ref: release
+          sparse-checkout: hack/generate-data-sources.sh
+          path: renovate-config
       - name: Validate and printout config
         run: jq -e . "${RENOVATE_CONFIG_FILE}"
       - name: Check token
@@ -94,7 +101,7 @@ jobs:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
       - name: Generate custom data sources
-        run: hack/generate-data-sources.sh
+        run: ./renovate-config/hack/generate-data-sources.sh
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@cf5954a2aac7999882d3de4e462499adde159d04 # v41.0.17
         with:

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -14,7 +14,7 @@ kustomize_save_arch_sources() {
     archs=("amd64" "arm64" "s390x")
 
     for arch in "${archs[@]}"; do
-          grep "linux_${arch}" kustomize-data.raw | jq -n --raw-input --slurp '{ "releases": [
+          grep "linux_${arch}" "${DATA_DIR}/kustomize-data.raw" | jq -n --raw-input --slurp '{ "releases": [
             inputs | split("\n")[]
             | select(test("^\\w+\\s+kustomize_"))
             | match("(?<digest>\\w+)\\s+kustomize_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")


### PR DESCRIPTION
 The introduction of #425 requires the execution of a script. In order for that script to be available during execution time, a sparse-checkout of renovate-config is required so that the specific script is present.