### PR TITLE
Revert "chore(deps): update renovate/renovate docker tag to v39.228.0"

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -37,7 +37,7 @@ concurrency: renovate
 
 env:
   # Specify what Renovate version to use (this is separate from the github-action version)
-  RENOVATE_VERSION: "39.228.0"
+  RENOVATE_VERSION: "39.213.5"
   # Repository taken from variable to keep configuration file generic
   RENOVATE_REPOSITORIES: ${{ github.repository }}
   # Onboarding not needed for self hosted

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ concurrency: renovate
 
 env:
   # Specify what Renovate version to use (this is separate from the github-action version)
-  RENOVATE_VERSION: "39.228.0"
+  RENOVATE_VERSION: "39.213.5"
   # Repository taken from variable to keep configuration file generic
   RENOVATE_REPOSITORIES: ${{ github.repository }}
   # Onboarding not needed for self hosted


### PR DESCRIPTION
Reverts rancher/renovate-config#434 as [per error](https://github.com/rancher/renovate-config/actions/runs/14224820531/job/39861667694):
> Unable to find image 'ghcr.io/renovatebot/renovate:39.228.0' locally

