### PR TITLE
Fix issue with PRs not being raised

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -61,7 +61,7 @@ env:
   RENOVATE_CONFIG_FILE: ${{ inputs.renovateConfig || '.github/renovate.json' }}
   # https://docs.renovatebot.com/configuration-options/#configmigration
   RENOVATE_CONFIG_MIGRATION: ${{ inputs.configMigration || 'true' }}
-  RENOVATE_DRY_RUN: ${{ inputs.configMigration || 'null' }}
+  RENOVATE_DRY_RUN: ${{ inputs.dryRun || 'null' }}
 
 permissions:
   contents: read

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -44,6 +44,13 @@
         "rancher/kuberlr-kubectl"
       ],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -33,7 +33,6 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.32.0"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -33,7 +33,6 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.33.0"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -44,6 +44,13 @@
         "rancher/kuberlr-kubectl"
       ],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -33,7 +33,6 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.31.0"

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -44,6 +44,13 @@
         "rancher/kuberlr-kubectl"
       ],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -33,7 +33,6 @@
         "gomod"
       ],
       "matchPackageNames": [
-        "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.33.0"


### PR DESCRIPTION
The [introduction](https://github.com/rancher/renovate-config/commit/1e57e550654877fba4ea9df8623afc69d58aca93) of `dryRun` was mistakenly getting the input value from `configMigration`, resulting in workflows always running on dry run mode.

Additionally, the `!k8s.io/kubernetes` rule does not seem to be taken into account together with the other rules of the same array, resulting on the wrong constraints being applied across most Go modules.

The disablement of GHA for non-main forks is orthogonal to the issues above.