### PR TITLE
Only handle security bumps for stable versions

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -1,8 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
@@ -12,12 +23,14 @@
       "allowedVersions": "<1.23.0"
     },
     {
+      "enabled": true,
       "matchDatasources": [
         "golang-version"
       ],
       "allowedVersions": "<1.23.0"
     },
     {
+      "enabled": true,
       "matchManagers": [
         "gomod"
       ],
@@ -29,6 +42,7 @@
       "allowedVersions": "<1.32.0"
     },
     {
+      "enabled": true,
       "matchManagers": [
         "gomod"
       ],
@@ -38,6 +52,7 @@
       "allowedVersions": "<0.32.0"
     },
     {
+      "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [
         "rancher/kuberlr-kubectl"
@@ -45,11 +60,11 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "enabled": false,
       "groupName": "GitHub Actions",
       "matchManagers": [
         "github-actions"
-      ],
-      "enabled": false
+      ]
     }
   ]
 }

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -58,13 +58,6 @@
         "rancher/kuberlr-kubectl"
       ],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "enabled": false,
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ]
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -1,8 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
@@ -12,12 +23,14 @@
       "allowedVersions": "<1.24.0"
     },
     {
+      "enabled": true,
       "matchDatasources": [
         "golang-version"
       ],
       "allowedVersions": "<1.24.0"
     },
     {
+      "enabled": true,
       "matchManagers": [
         "gomod"
       ],
@@ -29,6 +42,7 @@
       "allowedVersions": "<1.33.0"
     },
     {
+      "enabled": true,
       "matchManagers": [
         "gomod"
       ],
@@ -38,6 +52,7 @@
       "allowedVersions": "<0.33.0"
     },
     {
+      "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [
         "rancher/kuberlr-kubectl"
@@ -45,11 +60,11 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "enabled": false,
       "groupName": "GitHub Actions",
       "matchManagers": [
         "github-actions"
-      ],
-      "enabled": false
+      ]
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -58,13 +58,6 @@
         "rancher/kuberlr-kubectl"
       ],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "enabled": false,
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ]
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -1,8 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
+      "enabled": false,
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
@@ -12,12 +23,14 @@
       "allowedVersions": "<1.23.0"
     },
     {
+      "enabled": true,
       "matchDatasources": [
         "golang-version"
       ],
       "allowedVersions": "<1.23.0"
     },
     {
+      "enabled": true,
       "matchManagers": [
         "gomod"
       ],
@@ -29,6 +42,7 @@
       "allowedVersions": "<1.31.0"
     },
     {
+      "enabled": true,
       "matchManagers": [
         "gomod"
       ],
@@ -38,6 +52,7 @@
       "allowedVersions": "<0.31.0"
     },
     {
+      "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [
         "rancher/kuberlr-kubectl"
@@ -45,11 +60,11 @@
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
+      "enabled": false,
       "groupName": "GitHub Actions",
       "matchManagers": [
         "github-actions"
-      ],
-      "enabled": false
+      ]
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -58,13 +58,6 @@
         "rancher/kuberlr-kubectl"
       ],
       "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
-      "enabled": false,
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ]
     }
   ]
 }


### PR DESCRIPTION
besides a few exception which were already specified before.

This should reduce the amount of prs for the developers, like no need for ginkgo bumps in stable versions.

Following the [Renovate docs](https://docs.renovatebot.com/presets-security/#securityonly-security-updates) and the assumption that Renovate package rules are processed in order but that the subsequent enabled statements override the disabling of all the other packages.