### PR TITLE
Disable direct updates for k8s.io/gengo

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -52,6 +52,16 @@
       "allowedVersions": "<0.32.0"
     },
     {
+      "enabled": false,
+      "description": "Disable direct updates for k8s.io/gengo to prevent bumps for every new commit",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "k8s.io/gengo"
+      ]
+    },
+    {
       "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -52,6 +52,16 @@
       "allowedVersions": "<0.33.0"
     },
     {
+      "enabled": false,
+      "description": "Disable direct updates for k8s.io/gengo to prevent bumps for every new commit",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "k8s.io/gengo"
+      ]
+    },
+    {
       "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -52,6 +52,16 @@
       "allowedVersions": "<0.31.0"
     },
     {
+      "enabled": false,
+      "description": "Disable direct updates for k8s.io/gengo to prevent bumps for every new commit",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "k8s.io/gengo"
+      ]
+    },
+    {
       "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [


### PR DESCRIPTION
to prevent bumps for every new commit since Gengo does not have proper versioning.
It will still be bumped as a dependency of other components though.

For example prs like the following:
https://github.com/rancher/fleet/pull/3715
https://github.com/rancher/fleet/pull/3714
https://github.com/rancher/fleet/pull/3713