### PR TITLE
Add rules to disable digest updates for Go modules

### DIFF
--- a/default.json
+++ b/default.json
@@ -365,6 +365,16 @@
       ]
     },
     {
+      "description": "Disable digest updates (commit-based versions) for Go modules",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "golang.org/x/crypto/x509roots/fallback",
         "golang.org/x/exp"
@@ -372,7 +382,8 @@
       "matchUpdateTypes": [
         "patch",
         "digest"
-      ]
+      ],
+      "enabled": true
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -52,16 +52,6 @@
       "allowedVersions": "<0.32.0"
     },
     {
-      "enabled": false,
-      "description": "Disable direct updates for k8s.io/gengo to prevent bumps for every new commit",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "k8s.io/gengo"
-      ]
-    },
-    {
       "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -52,16 +52,6 @@
       "allowedVersions": "<0.33.0"
     },
     {
-      "enabled": false,
-      "description": "Disable direct updates for k8s.io/gengo to prevent bumps for every new commit",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "k8s.io/gengo"
-      ]
-    },
-    {
       "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -52,16 +52,6 @@
       "allowedVersions": "<0.31.0"
     },
     {
-      "enabled": false,
-      "description": "Disable direct updates for k8s.io/gengo to prevent bumps for every new commit",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "k8s.io/gengo"
-      ]
-    },
-    {
       "enabled": true,
       "description": "Disable major bumps",
       "matchPackageNames": [


### PR DESCRIPTION
Prevent digest bumps except for golang.org/x/crypto/x509roots/fallback and golang.org/x/exp.

This should fix the issue of regularly created prs for most basic repo changes.

Also remove k8s.io/gengo rule because it should be obsolete now with disabled digest updates.