### PR TITLE
Remove k8s.io/utils from k8s.io rule

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -49,6 +49,8 @@
       "matchPackageNames": [
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.32.0"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -49,6 +49,8 @@
       "matchPackageNames": [
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.33.0"

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -49,6 +49,8 @@
       "matchPackageNames": [
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.31.0"

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -35,6 +35,8 @@
       "matchPackageNames": [
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.33.0"


### PR DESCRIPTION
This was causing the disablement of digest bumps to be re-enabled.