### PR TITLE
Bump Go for Rancher Presets

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -20,14 +20,14 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.23.0"
+      "allowedVersions": "<1.24.0"
     },
     {
       "enabled": true,
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.23.0"
+      "allowedVersions": "<1.24.0"
     },
     {
       "enabled": true,

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -20,14 +20,14 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.23.0"
+      "allowedVersions": "<1.24.0"
     },
     {
       "enabled": true,
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.23.0"
+      "allowedVersions": "<1.24.0"
     },
     {
       "enabled": true,


### PR DESCRIPTION
Aligns the Go versions for presets v2.9 and v2.10.