### PR TITLE
Fix updating of k8s.io/kubernetes

### DIFF
--- a/default.json
+++ b/default.json
@@ -320,6 +320,9 @@
       ]
     },
     {
+      "matchManagers": [
+        "gomod"
+      ],
       "matchPackageNames": [
         "k8s.io/kubernetes",
         "kubernetes/kubernetes",

--- a/default.json
+++ b/default.json
@@ -309,7 +309,7 @@
         "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.32.0"
+      "allowedVersions": "<0.34.0"
     },
     {
       "matchManagers": ["gomod"],
@@ -326,7 +326,7 @@
         "rancher/kubectl"
       ],
       "groupName": "gomod-k8s-dependencies",
-      "allowedVersions": "<1.32.0"
+      "allowedVersions": "<1.34.0"
     },
     {
       "matchPackageNames": [

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -47,6 +47,7 @@
         "gomod"
       ],
       "matchPackageNames": [
+        "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
         "!k8s.io/utils",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -47,6 +47,7 @@
         "gomod"
       ],
       "matchPackageNames": [
+        "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
         "!k8s.io/utils",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -47,6 +47,7 @@
         "gomod"
       ],
       "matchPackageNames": [
+        "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
         "!k8s.io/utils",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -47,6 +47,7 @@
         "gomod"
       ],
       "matchPackageNames": [
+        "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
         "!k8s.io/utils",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -33,6 +33,7 @@
         "gomod"
       ],
       "matchPackageNames": [
+        "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",
         "!k8s.io/utils",


### PR DESCRIPTION
I have realized that we were updating most of the k8s libraries by Renovate but k8s.io/kubernetes was ignored, for example in this [pr](https://github.com/rancher/fleet/pull/3998).

This change excludes k8s.io/kubernetes from the broad rule to keep earlier version constraint of <1.*.

Renovate applies rules in order; later rules override scalar fields like allowedVersions.
The later broad rule for "k8s.io/**" sets "allowedVersions": "<0.34.0", which overrides the earlier <1.34.0 rule and in this succession made every v1.* Kubernetes release invalid.

My [example run](https://github.com/rancher/fleet/actions/runs/16983755389) of the new config created among others this [pr](https://github.com/rancher/fleet/pull/4004).