### PR TITLE
Trying new approach to allow security updates

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -1,51 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
+  "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "enabled": false,
-      "matchPackageNames": [
-        "*"
-      ]
+      "matchUpdateTypes": ["major","minor","patch","pin","digest"],
+      "enabled": false
     },
     {
-      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.24.0"
     },
     {
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["minor","patch","pin"],
       "enabled": true,
-      "matchDatasources": [
-        "golang-version"
-      ],
       "allowedVersions": "<1.24.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.32.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
@@ -56,15 +48,15 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<0.32.0"
     },
     {
-      "enabled": true,
       "description": "Disable major bumps",
-      "matchPackageNames": [
-        "rancher/kuberlr-kubectl"
-      ],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor","patch"],
+      "enabled": true
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -1,51 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
+  "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "enabled": false,
-      "matchPackageNames": [
-        "*"
-      ]
+      "matchUpdateTypes": ["major","minor","patch","pin","digest"],
+      "enabled": false
     },
     {
-      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.24.0"
     },
     {
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["minor","patch","pin"],
       "enabled": true,
-      "matchDatasources": [
-        "golang-version"
-      ],
       "allowedVersions": "<1.24.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.33.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
@@ -56,15 +48,15 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<0.33.0"
     },
     {
-      "enabled": true,
       "description": "Disable major bumps",
-      "matchPackageNames": [
-        "rancher/kuberlr-kubectl"
-      ],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor","patch"],
+      "enabled": true
     }
   ]
 }

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -1,51 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
+  "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "enabled": false,
-      "matchPackageNames": [
-        "*"
-      ]
+      "matchUpdateTypes": ["major","minor","patch","pin","digest"],
+      "enabled": false
     },
     {
-      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.25.0"
     },
     {
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["minor","patch","pin"],
       "enabled": true,
-      "matchDatasources": [
-        "golang-version"
-      ],
       "allowedVersions": "<1.25.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.34.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
@@ -56,15 +48,15 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<0.34.0"
     },
     {
-      "enabled": true,
       "description": "Disable major bumps",
-      "matchPackageNames": [
-        "rancher/kuberlr-kubectl"
-      ],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor","patch"],
+      "enabled": true
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -1,51 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
+  "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "enabled": false,
-      "matchPackageNames": [
-        "*"
-      ]
+      "matchUpdateTypes": ["major","minor","patch","pin","digest"],
+      "enabled": false
     },
     {
-      "enabled": true,
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.24.0"
     },
     {
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["minor","patch","pin"],
       "enabled": true,
-      "matchDatasources": [
-        "golang-version"
-      ],
       "allowedVersions": "<1.24.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<1.31.0"
     },
     {
-      "enabled": true,
-      "matchManagers": [
-        "gomod"
-      ],
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
@@ -56,15 +48,15 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
+      "matchUpdateTypes": ["minor","patch","pin"],
+      "enabled": true,
       "allowedVersions": "<0.31.0"
     },
     {
-      "enabled": true,
       "description": "Disable major bumps",
-      "matchPackageNames": [
-        "rancher/kuberlr-kubectl"
-      ],
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor","patch"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
I have realized that automatically bumping for security updates did not work. For example we did not got Renovate prs for [Helm v3.18.5.](https://github.com/rancherlabs/image-scanning/issues/6069).

So I was [trying](https://github.com/rancher/fleet/actions/runs/16993896183/job/48179789083) a new approach which seems to work, because it did create two prs for Fleet for Rancher 2.10 and [2.11](https://github.com/rancher/fleet/pull/4007) which bumped Go to [v1.24.5.](https://go.dev/doc/devel/release#go1.24.minor).
Go 1.23 is not supported anymore and the last Go 1.24.5 bump consist security updates.

What Renovate does not know is that the last Go 1.23.12 should have the same security fixes too, but the logic of fixing CVE's outside of our update constraints seems to work.
Following this I have closed those two prs and Renovate is not recreating them which is great.

### Explanation
When a dependency is disabled, Renovate won’t create normal update PRs nor vulnerability/security PRs for it. Only the few dependencies we explicitly re‑enabled in later rules (Go toolchain, k8s dependencies, etc.) get processed.
A later rule with "enabled": true does not override an earlier "enabled": false for the same dependency.
That's why we must narrow the disabling rule to allow security updates.

A rule that disables all regular update types (major/minor/patch/digest/pin) for everything still allows security updates because they are a separate flow.

Our specific rules need to allow  update types again though to be processed.
