### PR TITLE
Enforce version restrictions also on security bumps

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -40,12 +40,6 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
-        "!k8s.io/gengo",
-        "!k8s.io/gengo/**",
-        "!k8s.io/utils",
-        "!k8s.io/utils/**",
-        "!k8s.io/kube-openapi",
-        "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
       "matchUpdateTypes": ["patch"],

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -51,6 +51,19 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang",
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/**"
+      ],
+      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -15,13 +15,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.24.0"
     },
     {
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.24.0"
     },
@@ -32,7 +32,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.32.0"
     },
@@ -48,7 +48,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<0.32.0"
     },

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -44,7 +44,12 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.32.0"
+      "allowedVersions": "<0.32.0",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "k8s dependencies",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -40,12 +40,6 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
-        "!k8s.io/gengo",
-        "!k8s.io/gengo/**",
-        "!k8s.io/utils",
-        "!k8s.io/utils/**",
-        "!k8s.io/kube-openapi",
-        "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
       "matchUpdateTypes": ["patch"],

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -44,7 +44,12 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.33.0"
+      "allowedVersions": "<0.33.0",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "k8s dependencies",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -51,6 +51,19 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang",
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/**"
+      ],
+      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -15,13 +15,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.24.0"
     },
     {
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.24.0"
     },
@@ -32,7 +32,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.33.0"
     },
@@ -48,7 +48,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<0.33.0"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -40,12 +40,6 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
-        "!k8s.io/gengo",
-        "!k8s.io/gengo/**",
-        "!k8s.io/utils",
-        "!k8s.io/utils/**",
-        "!k8s.io/kube-openapi",
-        "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
       "matchUpdateTypes": ["patch"],

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -15,13 +15,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.25.0"
     },
     {
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.25.0"
     },
@@ -32,7 +32,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.34.0"
     },
@@ -48,7 +48,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<0.34.0"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -51,6 +51,19 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang",
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/**"
+      ],
+      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -44,7 +44,12 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.34.0"
+      "allowedVersions": "<0.34.0",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "k8s dependencies",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -40,12 +40,6 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
-        "!k8s.io/gengo",
-        "!k8s.io/gengo/**",
-        "!k8s.io/utils",
-        "!k8s.io/utils/**",
-        "!k8s.io/kube-openapi",
-        "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
       "matchUpdateTypes": ["patch"],

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -51,6 +51,19 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang",
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/**"
+      ],
+      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -44,7 +44,12 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.31.0"
+      "allowedVersions": "<0.31.0",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "k8s dependencies",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -15,13 +15,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.24.0"
     },
     {
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.24.0"
     },
@@ -32,7 +32,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<1.31.0"
     },
@@ -48,7 +48,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "matchUpdateTypes": ["minor","patch","pin"],
+      "matchUpdateTypes": ["patch"],
       "enabled": true,
       "allowedVersions": "<0.31.0"
     },

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -9,13 +9,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
Prevent Renovate from bumping k8s or go to unsupported and often
breaking minor versions, even for security updates.

Without this, Renovate would repeatedly recreate PRs (e.g this [one](https://github.com/rancher/fleet/pull/4039) for Fleet) for every new version of affected libraries throughout the release branch's lifecycle, reducing usefulness and causing annoyance.

If a new minor version is needed due to security fixes or EOL, the version restriction should be updated in the relevant config.