### PR TITLE
Make sure gomod-k8s-dependencies bumps provide a version

### DIFF
--- a/default.json
+++ b/default.json
@@ -304,6 +304,9 @@
         "gomod"
       ],
       "groupName": "gomod-k8s-dependencies",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "{{#if depName}}k8s - {{depName}}{{else}}{{groupName}}{{/if}}",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}",
       "matchPackageNames": [
         "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
@@ -332,10 +335,23 @@
       "allowedVersions": "<1.34.0"
     },
     {
+      "matchPackageNames": ["helm.sh/helm/v3"],
+      "groupName": "gomod-k8s-dependencies"
+    },
+    {
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
+        "!k8s.io/kubernetes",
+        "k8s.io/**",
+        "k8s.io/kubernetes",
+        "kubernetes/kubernetes",
+        "rancher/kubectl",
         "helm.sh/helm/v3"
       ],
-      "groupName": "gomod-k8s-dependencies"
+      "commitMessageAction": "update",
+      "commitMessageTopic": "{{#if depName}}k8s - {{depName}}{{else}}k8s dependencies{{/if}}",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
     },
     {
       "allowedVersions": "<15.8.0",


### PR DESCRIPTION
in the commit message and pr title.

Since there are usually multiple dependency updates as part of the group, one name is used for the title.

I think it is better to have one dependency name in the title with the according version then to just have "gomod-k8s-dependencies updated to some version".

To prevent titles like "Update gomod-k8s-dependencies (main)".