### PR TITLE
Expand managers for `rancher/kubectl`

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -26,7 +26,7 @@
       "allowedVersions": "<1.24.0"
     },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -26,7 +26,7 @@
       "allowedVersions": "<1.24.0"
     },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -26,7 +26,7 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -26,7 +26,7 @@
       "allowedVersions": "<1.24.0"
     },
     {
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -19,7 +19,9 @@
     },
     {
       "matchManagers": [
-        "gomod"
+        "gomod",
+        "regex",
+        "dockerfile"
       ],
       "matchPackageNames": [
         "rancher/kubectl",


### PR DESCRIPTION
Previous to this change, the version constraints to this package would not be enforced for `dockerfile` nor custom (`regex`) rules. This aligns the three managers and ensures that the preset will work correctly across them.

Fixes https://github.com/rancher/compliance-operator/pull/82#issuecomment-3253114905