### PR TITLE
chore(deps): support K8s 1.34 and Go 1.25

### DIFF
--- a/default.json
+++ b/default.json
@@ -10,7 +10,7 @@
   "automergeStrategy": "merge-commit",
   "prConcurrentLimit": 0,
   "constraints": {
-    "go": "<1.25"
+    "go": "<1.26"
   },
   "postUpdateOptions": [
     "gomodTidy",
@@ -309,7 +309,7 @@
         "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.34.0"
+      "allowedVersions": "<0.35.0"
     },
     {
       "matchManagers": ["gomod"],
@@ -329,7 +329,7 @@
         "rancher/kubectl"
       ],
       "groupName": "gomod-k8s-dependencies",
-      "allowedVersions": "<1.34.0"
+      "allowedVersions": "<1.35.0"
     },
     {
       "matchPackageNames": [
@@ -351,13 +351,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "allowedVersions": "<1.0.0",
@@ -394,7 +394,7 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchCurrentValue": "1.24",
+      "matchCurrentValue": "1.25",
       "enabled": false
     },
     {

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -28,7 +28,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "allowedVersions": "<1.34.0"
+      "allowedVersions": "<1.35.0"
     },
     {
       "matchManagers": [
@@ -44,7 +44,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.34.0"
+      "allowedVersions": "<0.35.0"
     }
   ]
 }


### PR DESCRIPTION
outside of the release branches.