### PR TITLE
Restrict go to <1.25.0 in main

### DIFF
--- a/rancher-main.json
+++ b/rancher-main.json
@@ -9,13 +9,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.26.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.26.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "matchManagers": [


### PR DESCRIPTION
because Rancher 2.13 will most likely stay - at least in the beginning - on Go 1.24.

For more information check out the slack channel #proj-rancher-k8s-new-minor-support