### PR TITLE
Fix update issues

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -42,7 +42,7 @@
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
@@ -53,7 +53,7 @@
     },
     {
       "description": "Restrict kubectl/k8s versions to below 1.32.0",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -9,6 +9,7 @@
       "enabled": false
     },
     {
+      "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",
         "go",
@@ -16,16 +17,31 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict Go versions to below 1.24.0",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
       "allowedVersions": "<1.24.0"
     },
     {
+      "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict golang-version to below 1.24.0",
+      "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.24.0"
     },
     {
+      "description": "Enable patch updates for kubectl/k8s packages",
       "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
@@ -33,10 +49,20 @@
         "k8s.io/kubernetes"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict kubectl/k8s versions to below 1.32.0",
+      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
       "allowedVersions": "<1.32.0"
     },
     {
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
@@ -44,12 +70,20 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.32.0",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "commitMessageAction": "update",
       "commitMessageTopic": "k8s dependencies",
       "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+    },
+    {
+      "description": "Restrict k8s.io dependencies to below 0.32.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.32.0"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -42,7 +42,7 @@
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
@@ -53,7 +53,7 @@
     },
     {
       "description": "Restrict kubectl/k8s versions to below 1.33.0",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -9,6 +9,7 @@
       "enabled": false
     },
     {
+      "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",
         "go",
@@ -16,16 +17,31 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict Go versions to below 1.24.0",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
       "allowedVersions": "<1.24.0"
     },
     {
+      "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict golang-version to below 1.24.0",
+      "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.24.0"
     },
     {
+      "description": "Enable patch updates for kubectl/k8s packages",
       "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
@@ -33,10 +49,20 @@
         "k8s.io/kubernetes"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict kubectl/k8s versions to below 1.33.0",
+      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
       "allowedVersions": "<1.33.0"
     },
     {
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
@@ -44,12 +70,20 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.33.0",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "commitMessageAction": "update",
       "commitMessageTopic": "k8s dependencies",
       "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+    },
+    {
+      "description": "Restrict k8s.io dependencies to below 0.33.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.33.0"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -9,6 +9,7 @@
       "enabled": false
     },
     {
+      "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",
         "go",
@@ -16,16 +17,31 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict Go versions to below 1.25.0",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
       "allowedVersions": "<1.25.0"
     },
     {
+      "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict golang-version to below 1.25.0",
+      "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.25.0"
     },
     {
+      "description": "Enable patch updates for kubectl/k8s packages",
       "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
@@ -33,10 +49,20 @@
         "k8s.io/kubernetes"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict kubectl/k8s versions to below 1.34.0",
+      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
       "allowedVersions": "<1.34.0"
     },
     {
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
@@ -44,12 +70,20 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.34.0",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "commitMessageAction": "update",
       "commitMessageTopic": "k8s dependencies",
       "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+    },
+    {
+      "description": "Restrict k8s.io dependencies to below 0.34.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.34.0"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -42,7 +42,7 @@
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
@@ -53,7 +53,7 @@
     },
     {
       "description": "Restrict kubectl/k8s versions to below 1.34.0",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -42,7 +42,7 @@
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
@@ -53,7 +53,7 @@
     },
     {
       "description": "Restrict kubectl/k8s versions to below 1.31.0",
-      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -9,6 +9,7 @@
       "enabled": false
     },
     {
+      "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",
         "go",
@@ -16,16 +17,31 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict Go versions to below 1.24.0",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
       "allowedVersions": "<1.24.0"
     },
     {
+      "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict golang-version to below 1.24.0",
+      "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.24.0"
     },
     {
+      "description": "Enable patch updates for kubectl/k8s packages",
       "matchManagers": ["gomod", "regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
@@ -33,10 +49,20 @@
         "k8s.io/kubernetes"
       ],
       "matchUpdateTypes": ["patch"],
-      "enabled": true,
+      "enabled": true
+    },
+    {
+      "description": "Restrict kubectl/k8s versions to below 1.31.0",
+      "matchManagers": ["gomod", "regex", "dockerfile"],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
+      ],
       "allowedVersions": "<1.31.0"
     },
     {
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
@@ -44,12 +70,20 @@
       ],
       "matchUpdateTypes": ["patch"],
       "enabled": true,
-      "allowedVersions": "<0.31.0",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "commitMessageAction": "update",
       "commitMessageTopic": "k8s dependencies",
       "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+    },
+    {
+      "description": "Restrict k8s.io dependencies to below 0.31.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.31.0"
     },
     {
       "description": "Disable major bumps",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -20,7 +20,7 @@
     {
       "matchManagers": [
         "gomod",
-        "regex",
+        "custom.regex",
         "dockerfile"
       ],
       "matchPackageNames": [


### PR DESCRIPTION
I was wondering why our Go version was not updated in the Rancher 2.12 related release branch.

It turns out that some rules were combining `matchUpdateTypes` and `allowedVersions` in the same object, which Renovate doesn't allow. At the same time Renovate itself did not fail, so the issue went unnoticed.

On top `make validate` did not verify the special rancher configurations, otherwise the error would have shown in a pr.
I have split the according rules and have adapted make validate to verify all renovate config files - also the repo ones (I suppose it does not hurt).

[Successful test run](https://github.com/rancher/fleet/actions/runs/18526067208/job/52797075573) against Fleet.

And these are the prs created by it:
https://github.com/rancher/fleet/pull/4229
https://github.com/rancher/fleet/pull/4230