### PR TITLE
Add regex rule to bump pinned slsactl from `install-slsactl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ TMP_DIR := $(shell mkdir -p build/tmp && realpath build/tmp)
 RENOVATE_IMG := renovate/renovate:full
 RENOVATE_CONFIGS := $(shell find . .github files -maxdepth 1 -name '*.json' 2>/dev/null)
 
-VALIDATE_FILE := docker run --rm -v $(shell pwd):/repo:ro -e LOG_LEVEL=debug \
+VALIDATE_FILE := docker run --rm -v $(shell pwd):/repo:Z -e LOG_LEVEL=debug \
 		$(RENOVATE_IMG) renovate-config-validator --strict
 
 # When GITHUB_COM_TOKEN is provided, it is automatically redacted from logs.
-TEST_FILE := docker run --rm -v $(TMP_DIR):/repo:ro -e LOG_LEVEL=debug \
+TEST_FILE := docker run --rm -v $(TMP_DIR):/repo:Z -e LOG_LEVEL=debug \
 	-e GITHUB_COM_TOKEN --workdir /repo $(RENOVATE_IMG) renovate --platform=local --dry-run=full
 
 validate: # validates (strict mode) all renovate files for syntax errors.

--- a/default.json
+++ b/default.json
@@ -38,6 +38,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.ya?ml/"
+      ],
+      "matchStrings": [
+        ".*?- uses:\\s*rancherlabs/slsactl/actions/install-slsactl@.*?\\s*with:\\s*(?:[^\\n]*\\n\\s*)*?version:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "rancherlabs/slsactl",
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/",
         "/hack/make/deps.mk/"


### PR DESCRIPTION
The install-slsactl GHA can install arbitrary versions of slsactl, which are pinned by using `with.version`. The new regex ensures that renovate will propose bumps for such cases.


Fixes https://github.com/rancher/renovate-config/issues/572.