### PR TITLE
Add retry for curl commands

### DIFF
--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -7,18 +7,18 @@ DATA_DIR="data"
 ARCHS=("amd64" "arm64" "s390x")
 
 kustomize_fetch_data() {
-    curl -L https://api.github.com/repos/kubernetes-sigs/kustomize/releases | \
+    curl --retry 3 --retry-connrefused -L https://api.github.com/repos/kubernetes-sigs/kustomize/releases | \
     jq -r '.[].assets[] | select(.name == "checksums.txt") | .browser_download_url' | \
-    head -n3 | xargs -I{} curl -L {} >> "${DATA_DIR}/kustomize-data.raw"
+    head -n3 | xargs -I{} curl --retry 3 --retry-connrefused -L {} >> "${DATA_DIR}/kustomize-data.raw"
 }
 
 kubectl_fetch_data() {
     # Return the last 4 patch releases across the supported minors.
-    versions=$(curl -L https://api.github.com/repos/kubernetes/kubernetes/releases | jq -r '.[].tag_name' | grep -v alpha | grep -v rc | grep -v beta | head -n 4)
+    versions=$(curl --retry 3 --retry-connrefused -L https://api.github.com/repos/kubernetes/kubernetes/releases | jq -r '.[].tag_name' | grep -v alpha | grep -v rc | grep -v beta | head -n 4)
     
     echo "${versions}" | while IFS= read -r version; do
         for arch in "${ARCHS[@]}"; do
-            curl -L "https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl.sha256" >> "${DATA_DIR}/kubectl-data.raw"
+            curl --retry 3 --retry-connrefused -L "https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl.sha256" >> "${DATA_DIR}/kubectl-data.raw"
             echo "  kubectl_${version}_linux_${arch}.tar.gz" >> "${DATA_DIR}/kubectl-data.raw"
         done
     done


### PR DESCRIPTION
The local sources are failing at times due to curl not being able to fetch some resources. This ensures that it will always retry up to 3 times, instead of failing its execution.