### PR TITLE
Improve update process

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: "null"
         type: string
+      extendsPreset:
+        description: "Override renovate extends preset (default: 'github>rancher/renovate-config#release')."
+        required: false
+        default: "github>rancher/renovate-config#release"
+        type: string
     secrets:
       override-token:
         description: "Overrides the GH App Token. Use this to run from forks which don't have access to the GH App."
@@ -69,6 +74,8 @@ env:
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || 'null' }}
   # Override minimumReleaseAge if set
   RENOVATE_MINIMUM_RELEASE_AGE: ${{ inputs.minimumReleaseAge != 'null' && inputs.minimumReleaseAge || '' }}
+  # Override renovate extends preset if set
+  RENOVATE_EXTENDS_PRESET: ${{ inputs.extendsPreset || 'github>rancher/renovate-config#release' }}
 
 permissions:
   contents: read

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -34,6 +34,11 @@ on:
         # https://docs.renovatebot.com/self-hosted-configuration/#dryrun
         default: "null"
         type: string
+      minimumReleaseAge:
+        description: "Override minimumReleaseAge for a one-time run (e.g., '0 days' to disable delay)"
+        required: false
+        default: "null"
+        type: string
     secrets:
       override-token:
         description: "Overrides the GH App Token. Use this to run from forks which don't have access to the GH App."
@@ -62,6 +67,8 @@ env:
   # https://docs.renovatebot.com/configuration-options/#configmigration
   RENOVATE_CONFIG_MIGRATION: ${{ inputs.configMigration || 'true' }}
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || 'null' }}
+  # Override minimumReleaseAge if set
+  RENOVATE_MINIMUM_RELEASE_AGE: ${{ inputs.minimumReleaseAge != 'null' && inputs.minimumReleaseAge || '' }}
 
 permissions:
   contents: read

--- a/default.json
+++ b/default.json
@@ -305,6 +305,17 @@
   ],
   "packageRules": [
     {
+      "description": "Restrict helm/chart-testing-action below 2.8.0",
+      "matchPackageNames": [
+        "helm/chart-testing-action"
+      ],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "allowedVersions": "<2.8.0",
+      "minimumReleaseAge": "14 days"
+    },
+    {
       "matchPackageNames": [
         "renovate/renovate"
       ],

--- a/default.json
+++ b/default.json
@@ -457,6 +457,11 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "description": "Restrict rancherlabs/slsactl",
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "allowedVersions": "<=v0.1.2"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -9,6 +9,7 @@
   ],
   "automergeStrategy": "merge-commit",
   "prConcurrentLimit": 0,
+  "minimumReleaseAge": "5 days",
   "constraints": {
     "go": "<1.26"
   },
@@ -387,7 +388,8 @@
       "matchDepTypes": [
         "action"
       ],
-      "pinDigests": true
+      "pinDigests": true,
+      "minimumReleaseAge": "14 days"
     },
     {
       "matchPackageNames": [

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -36,6 +36,11 @@ on:
         required: false
         default: "null"
         type: string
+      extendsPreset:
+        description: "Override renovate extends preset (default: 'github>rancher/renovate-config#release')."
+        required: false
+        default: "release"
+        type: string
 
   schedule:
     - cron: '30 4,6 * * 1-5'
@@ -53,5 +58,6 @@ jobs:
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
       renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
       minimumReleaseAge: ${{ inputs.minimumReleaseAge || 'null' }}
+      extendsPreset: ${{ inputs.extendsPreset || 'github>rancher/renovate-config#release' }}
     secrets:
       override-token: "${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}"

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: ".github/renovate.json"
         type: string
+      minimumReleaseAge:
+        description: "Override minimumReleaseAge for a one-time run (e.g., '0 days' to disable delay)"
+        required: false
+        default: "null"
+        type: string
 
   schedule:
     - cron: '30 4,6 * * 1-5'
@@ -47,5 +52,6 @@ jobs:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
       renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
+      minimumReleaseAge: ${{ inputs.minimumReleaseAge || 'null' }}
     secrets:
       override-token: "${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}"

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rancher/renovate-config#release"],
+  "extends": ["{{ or env.RENOVATE_EXTENDS_PRESET 'github>rancher/renovate-config#release' }}"],
   "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rancher/renovate-config#release"],
+  "extends": ["{{ or env.RENOVATE_EXTENDS_PRESET 'github>rancher/renovate-config#release' }}"],
   "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rancher/renovate-config#release"],
+  "extends": ["{{ or env.RENOVATE_EXTENDS_PRESET 'github>rancher/renovate-config#release' }}"],
   "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rancher/renovate-config#release"],
+  "extends": ["{{ or env.RENOVATE_EXTENDS_PRESET 'github>rancher/renovate-config#release' }}"],
   "packageRules": [
     {
       "matchPackageNames": [

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rancher/renovate-config#release"],
+  "extends": ["{{ or env.RENOVATE_EXTENDS_PRESET 'github>rancher/renovate-config#release' }}"],
   "vulnerabilityAlerts": { "enabled": true },
   "osvVulnerabilityAlerts": true,
   "packageRules": [

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>rancher/renovate-config#release"],
+  "extends": ["{{ or env.RENOVATE_EXTENDS_PRESET 'github>rancher/renovate-config#release' }}"],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
- Restrict helm/chart-testing-action to versions below 2.8.0 to prevent pulling in astral-sh/setup-uv as requirement.
- Add minimum release age settings for dependencies for bumps to be tested and verified by the community
- Add minimumReleaseAge input to renovate workflows for one-time overrides
- Restrict rancherlabs/slsactl to v0.1.2
- Use dynamic extends reference configured by GH action