### PR TITLE
Fix skip failure

### DIFF
--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -49,12 +49,10 @@ kubectl_save_arch_sources() {
 main() {
     mkdir -p "${DATA_DIR}"
 
-    grep -r -q --exclude-dir=renovate-config "# renovate-local:" ./
-
     # Only fetch custom data in projects where they are used.
     # For projects where "# renovate-local" is not applied, skip this
     # process altogether.
-    if [ $? -eq 0 ]; then
+    if grep -r -q --exclude-dir=renovate-config "# renovate-local:" ./; then
         kustomize_fetch_data
         kustomize_save_arch_sources
         kubectl_fetch_data


### PR DESCRIPTION
The grep command was being executed outside of an if, which was resulting on failure on all repositories that do not use renovate-local.

Follow-up from #587.