### PR TITLE
Some maintenance fixes

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,6 +13,7 @@
   "automergeStrategy": "merge-commit",
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "5 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "constraints": {
     "go": "<1.26"
   },

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -20,14 +20,14 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.24.0",
+      "description": "Restrict Go versions to below 1.25.0",
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "description": "Enable patch updates for golang-version datasource",
@@ -36,9 +36,9 @@
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.24.0",
+      "description": "Restrict golang-version to below 1.25.0",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -20,14 +20,14 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.24.0",
+      "description": "Restrict Go versions to below 1.25.0",
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "description": "Enable patch updates for golang-version datasource",
@@ -36,9 +36,9 @@
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.24.0",
+      "description": "Restrict golang-version to below 1.25.0",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -1,8 +1,26 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "vulnerabilityAlerts": { "enabled": true },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
+      "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
+      "enabled": false
+    },
+    {
+      "description": "Enable patch updates for Go packages",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Restrict Go versions to below 1.25.0",
       "matchPackageNames": [
         "golang",
         "go",
@@ -12,17 +30,30 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "matchDatasources": [
-        "golang-version"
-      ],
+      "description": "Enable patch updates for golang-version datasource",
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Restrict golang-version to below 1.25.0",
+      "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.25.0"
     },
     {
-      "matchManagers": [
-        "gomod",
-        "custom.regex",
-        "dockerfile"
+      "description": "Enable patch updates for kubectl/k8s packages",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": [
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/kubernetes"
       ],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Restrict kubectl/k8s versions to below 1.35.0",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
@@ -31,20 +62,47 @@
       "allowedVersions": "<1.35.0"
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
+      "description": "Enable patch updates for k8s.io dependencies",
+      "matchManagers": ["gomod"],
       "matchPackageNames": [
         "!k8s.io/kubernetes",
-        "!k8s.io/gengo",
-        "!k8s.io/gengo/**",
-        "!k8s.io/utils",
-        "!k8s.io/utils/**",
-        "!k8s.io/kube-openapi",
-        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "k8s dependencies",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+    },
+    {
+      "description": "Restrict k8s.io dependencies to below 0.35.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.35.0"
+    },
+    {
+      "description": "Disable major bumps",
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor","patch"],
+      "enabled": true
+    },
+    {
+      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang",
+        "rancher/kubectl",
+        "kubernetes/kubernetes",
+        "k8s.io/**"
+      ],
+      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -20,14 +20,14 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.24.0",
+      "description": "Restrict Go versions to below 1.25.0",
       "matchPackageNames": [
         "golang",
         "go",
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "description": "Enable patch updates for golang-version datasource",
@@ -36,9 +36,9 @@
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.24.0",
+      "description": "Restrict golang-version to below 1.25.0",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<1.25.0"
     },
     {
       "description": "Enable patch updates for kubectl/k8s packages",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -9,13 +9,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.25.0"
+      "allowedVersions": "<1.26.0"
     },
     {
       "matchManagers": [
@@ -28,7 +28,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "allowedVersions": "<1.35.0"
+      "allowedVersions": "<1.36.0"
     },
     {
       "matchManagers": [
@@ -44,7 +44,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.35.0"
+      "allowedVersions": "<0.36.0"
     }
   ]
 }


### PR DESCRIPTION
- Update minimumReleaseAgeBehaviour to timestamp-optional
- Update Go version restrictions to be at least 1.24
- Allow Go 1.25 and Kubernetes 1.35 in Rancher main
- Use usual patterns for rancher-2.13.json
