### PR TITLE
Another approach to make sure security vulnerabilities get fixed

### DIFF
--- a/default.json
+++ b/default.json
@@ -465,7 +465,13 @@
     {
       "description": "Restrict rancherlabs/slsactl",
       "matchPackageNames": ["rancherlabs/slsactl"],
-      "allowedVersions": "<=v0.1.10"
+      "allowedVersions": "<=v0.1.10",
+      "groupName": "slsactl"
+    },
+    {
+      "description": "Group slsactl GitHub Action with version parameter",
+      "matchPackageNames": ["rancherlabs/slsactl/**"],
+      "groupName": "slsactl"
     }
   ]
 }

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -9,6 +9,11 @@
       "enabled": false
     },
     {
+      "description": "Enable updates for packages with known vulnerabilities",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -9,6 +9,11 @@
       "enabled": false
     },
     {
+      "description": "Enable updates for packages with known vulnerabilities",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -9,6 +9,11 @@
       "enabled": false
     },
     {
+      "description": "Enable updates for packages with known vulnerabilities",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -9,6 +9,11 @@
       "enabled": false
     },
     {
+      "description": "Enable updates for packages with known vulnerabilities",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -9,6 +9,11 @@
       "enabled": false
     },
     {
+      "description": "Enable updates for packages with known vulnerabilities",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",


### PR DESCRIPTION
and group slsactl bumps so we get only one pr instead of two (one for the specified version and one for the github action).