### PR TITLE
Move osvVulnerabilityAlerts to top-level config

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,6 +3,7 @@
   "extends":[
     "mergeConfidence:age-confidence-badges"
   ],
+  "osvVulnerabilityAlerts": true,
   "baseBranchPatterns": [
     "main"
   ],

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
   "vulnerabilityAlerts": { "enabled": true },
-  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
   "vulnerabilityAlerts": { "enabled": true },
-  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
   "vulnerabilityAlerts": { "enabled": true },
-  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
   "vulnerabilityAlerts": { "enabled": true },
-  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
   "vulnerabilityAlerts": { "enabled": true },
-  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],


### PR DESCRIPTION
[osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts) is a top-level only option and was being silently ignored when set in release presets loaded via packageRules.

Moving it to default.json should allow OSV vulnerability scanning.