### PR TITLE
Small improvements

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -13,6 +13,12 @@
       "enabled": true
     },
     {
+      "description": "Disable vulnerability updates for test/dev dependencies",
+      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": false
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -13,6 +13,11 @@
       "enabled": true
     },
     {
+      "description": "Enable SLSACTL updates",
+      "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -13,6 +13,12 @@
       "enabled": true
     },
     {
+      "description": "Disable vulnerability updates for test/dev dependencies",
+      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": false
+    },
+    {
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
       "enabled": true

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -13,6 +13,11 @@
       "enabled": true
     },
     {
+      "description": "Enable SLSACTL updates",
+      "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -13,6 +13,12 @@
       "enabled": true
     },
     {
+      "description": "Disable vulnerability updates for test/dev dependencies",
+      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": false
+    },
+    {
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
       "enabled": true

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -13,6 +13,11 @@
       "enabled": true
     },
     {
+      "description": "Enable SLSACTL updates",
+      "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
+      "enabled": true
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -13,6 +13,12 @@
       "enabled": true
     },
     {
+      "description": "Disable vulnerability updates for test/dev dependencies",
+      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": false
+    },
+    {
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
       "enabled": true

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -13,6 +13,12 @@
       "enabled": true
     },
     {
+      "description": "Disable vulnerability updates for test/dev dependencies",
+      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": false
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",


### PR DESCRIPTION
* Enable SLSACTL updates for Rancher 2.11+
   But please only bump the slsactl version in `defaults.json` when absolutely necessary or after a longer time because it will create at least three prs every time for each project using SLSACTL via Github actions.
* Block vulnerability updates for test/dev dependencies, to prevent prs like these:
   * https://github.com/rancher/rancher/pull/53026
   * https://github.com/rancher/rancher/pull/53023

   If this works as expected it would have prevented most prs after the recent updates while keeping the important ones.
