### PR TITLE
Group kubernetes/k8s.io packages and replace version by patch level restriction

### DIFF
--- a/default.json
+++ b/default.json
@@ -473,6 +473,21 @@
       "description": "Group slsactl GitHub Action with version parameter",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "groupName": "slsactl"
+    },
+    {
+      "description": "Group kubernetes/kubernetes and k8s.io/kubernetes",
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+    },
+    {
+      "description": "Group other k8s.io dependencies with kubernetes/kubernetes",
+      "matchPackageNames": ["k8s.io/**"],
+      "groupName": "Kubernetes dependencies"
     }
   ]
 }

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -51,49 +51,25 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "description": "Enable patch updates for kubectl/k8s packages",
+      "description": "Enable and restrict kubectl to below 1.32.0",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["rancher/kubectl"],
+      "allowedVersions": "<1.32.0",
       "enabled": true
     },
     {
-      "description": "Restrict kubectl/k8s versions to below 1.32.0",
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "allowedVersions": "<1.32.0"
+      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.32.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.32.0",
+      "enabled": true
     },
     {
-      "description": "Enable patch updates for k8s.io dependencies",
+      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.32.0",
       "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "matchUpdateTypes": ["patch"],
-      "enabled": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "k8s dependencies",
-      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
-    },
-    {
-      "description": "Restrict k8s.io dependencies to below 0.32.0",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.32.0"
+      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "allowedVersions": "<0.32.0",
+      "enabled": true
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -63,7 +63,7 @@
       "enabled": true
     },
     {
-      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
       "matchPackageNames": [
         "golang",
         "go",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -30,49 +30,34 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.25.0",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang"
-      ],
-      "allowedVersions": "<1.25.0"
-    },
-    {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.25.0",
-      "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25.0"
-    },
-    {
-      "description": "Enable and restrict kubectl to below 1.32.0",
+      "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "allowedVersions": "<1.32.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.32.0",
+      "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.32.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.32.0",
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "allowedVersions": "<0.32.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Disable major bumps",
+      "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -35,49 +35,34 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.25.0",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang"
-      ],
-      "allowedVersions": "<1.25.0"
-    },
-    {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.25.0",
-      "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25.0"
-    },
-    {
-      "description": "Enable and restrict kubectl to below 1.33.0",
+      "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "allowedVersions": "<1.33.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.33.0",
+      "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.33.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.33.0",
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "allowedVersions": "<0.33.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Disable major bumps",
+      "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -56,49 +56,25 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "description": "Enable patch updates for kubectl/k8s packages",
+      "description": "Enable and restrict kubectl to below 1.33.0",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["rancher/kubectl"],
+      "allowedVersions": "<1.33.0",
       "enabled": true
     },
     {
-      "description": "Restrict kubectl/k8s versions to below 1.33.0",
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "allowedVersions": "<1.33.0"
+      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.33.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.33.0",
+      "enabled": true
     },
     {
-      "description": "Enable patch updates for k8s.io dependencies",
+      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.33.0",
       "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "matchUpdateTypes": ["patch"],
-      "enabled": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "k8s dependencies",
-      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
-    },
-    {
-      "description": "Restrict k8s.io dependencies to below 0.33.0",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.33.0"
+      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "allowedVersions": "<0.33.0",
+      "enabled": true
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -68,7 +68,7 @@
       "enabled": true
     },
     {
-      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
       "matchPackageNames": [
         "golang",
         "go",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -35,49 +35,34 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.25.0",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang"
-      ],
-      "allowedVersions": "<1.25.0"
-    },
-    {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.25.0",
-      "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25.0"
-    },
-    {
-      "description": "Enable and restrict kubectl to below 1.34.0",
+      "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "allowedVersions": "<1.34.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.34.0",
+      "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.34.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.34.0",
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "allowedVersions": "<0.34.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Disable major bumps",
+      "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -56,49 +56,25 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "description": "Enable patch updates for kubectl/k8s packages",
+      "description": "Enable and restrict kubectl to below 1.34.0",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["rancher/kubectl"],
+      "allowedVersions": "<1.34.0",
       "enabled": true
     },
     {
-      "description": "Restrict kubectl/k8s versions to below 1.34.0",
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "allowedVersions": "<1.34.0"
+      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.34.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.34.0",
+      "enabled": true
     },
     {
-      "description": "Enable patch updates for k8s.io dependencies",
+      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.34.0",
       "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "matchUpdateTypes": ["patch"],
-      "enabled": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "k8s dependencies",
-      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
-    },
-    {
-      "description": "Restrict k8s.io dependencies to below 0.34.0",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.34.0"
+      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "allowedVersions": "<0.34.0",
+      "enabled": true
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -68,7 +68,7 @@
       "enabled": true
     },
     {
-      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
       "matchPackageNames": [
         "golang",
         "go",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -35,49 +35,34 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.25.0",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang"
-      ],
-      "allowedVersions": "<1.25.0"
-    },
-    {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.25.0",
-      "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25.0"
-    },
-    {
-      "description": "Enable and restrict kubectl to below 1.35.0",
+      "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "allowedVersions": "<1.35.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.35.0",
+      "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.35.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.35.0",
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "allowedVersions": "<0.35.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Disable major bumps",
+      "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -68,7 +68,7 @@
       "enabled": true
     },
     {
-      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
       "matchPackageNames": [
         "golang",
         "go",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -56,49 +56,25 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "description": "Enable patch updates for kubectl/k8s packages",
+      "description": "Enable and restrict kubectl to below 1.35.0",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["rancher/kubectl"],
+      "allowedVersions": "<1.35.0",
       "enabled": true
     },
     {
-      "description": "Restrict kubectl/k8s versions to below 1.35.0",
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "allowedVersions": "<1.35.0"
+      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.35.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.35.0",
+      "enabled": true
     },
     {
-      "description": "Enable patch updates for k8s.io dependencies",
+      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.35.0",
       "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "matchUpdateTypes": ["patch"],
-      "enabled": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "k8s dependencies",
-      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
-    },
-    {
-      "description": "Restrict k8s.io dependencies to below 0.35.0",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.35.0"
+      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "allowedVersions": "<0.35.0",
+      "enabled": true
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -51,49 +51,25 @@
       "allowedVersions": "<1.25.0"
     },
     {
-      "description": "Enable patch updates for kubectl/k8s packages",
+      "description": "Enable and restrict kubectl to below 1.31.0",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "matchUpdateTypes": ["patch"],
+      "matchPackageNames": ["rancher/kubectl"],
+      "allowedVersions": "<1.31.0",
       "enabled": true
     },
     {
-      "description": "Restrict kubectl/k8s versions to below 1.31.0",
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": [
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
-      ],
-      "allowedVersions": "<1.31.0"
+      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.31.0",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.31.0",
+      "enabled": true
     },
     {
-      "description": "Enable patch updates for k8s.io dependencies",
+      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.31.0",
       "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "matchUpdateTypes": ["patch"],
-      "enabled": true,
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "k8s dependencies",
-      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
-    },
-    {
-      "description": "Restrict k8s.io dependencies to below 0.31.0",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.31.0"
+      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "allowedVersions": "<0.31.0",
+      "enabled": true
     },
     {
       "description": "Disable major bumps",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -30,49 +30,34 @@
       "enabled": true
     },
     {
-      "description": "Restrict Go versions to below 1.25.0",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang"
-      ],
-      "allowedVersions": "<1.25.0"
-    },
-    {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Restrict golang-version to below 1.25.0",
-      "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25.0"
-    },
-    {
-      "description": "Enable and restrict kubectl to below 1.31.0",
+      "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "allowedVersions": "<1.31.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict kubernetes/kubernetes and k8s.io/kubernetes to below 1.31.0",
+      "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.31.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Enable and restrict k8s.io dependencies (excluding k8s.io/kubernetes) to below 0.31.0",
+      "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "allowedVersions": "<0.31.0",
+      "matchUpdateTypes": ["patch"],
       "enabled": true
     },
     {
-      "description": "Disable major bumps",
+      "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -63,7 +63,7 @@
       "enabled": true
     },
     {
-      "description": "Disable vulnerability alerts for all k8s and golang modules to prevent non-patch level bumps",
+      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
       "matchPackageNames": [
         "golang",
         "go",


### PR DESCRIPTION
If we only allow patch level bumps there is no risk of getting minor bumps while being able to manually update Go from 1.24 to 1.25 and then Renovate would still be able to maintain that new version without any Renovate config changes.

This should also make maintaining the different Rancher releases easier.

## Expected Changes summary

* Kubernetes prs should be grouped to one, so k8s libraries and kubernetes binaries are not update in separate prs
* Kubernetes prs should have the version in the pr title, also for bumps on the `main` channel
* Handling of release bumps of k8s and go should not change unless the minor version is bumped manually by a developer - then Renovate should provide patch level bumps for this version too