### PR TITLE
Further improvements

### DIFF
--- a/default.json
+++ b/default.json
@@ -434,14 +434,15 @@
       ]
     },
     {
-      "description": "Restrict rancherlabs/slsactl",
+      "description": "Group and restrict rancherlabs/slsactl (GitHub tag and version parameter)",
       "matchPackageNames": ["rancherlabs/slsactl"],
       "allowedVersions": "<=v0.1.10",
       "groupName": "slsactl"
     },
     {
-      "description": "Group slsactl GitHub Action with version parameter",
+      "description": "Group slsactl GitHub Action (with digest)",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
+      "allowedVersions": "<=v0.1.10",
       "groupName": "slsactl"
     },
     {

--- a/default.json
+++ b/default.json
@@ -328,42 +328,12 @@
       "groupName": "renovate-bumps"
     },
     {
-      "matchManagers": [
-        "gomod"
-      ],
-      "groupName": "gomod-k8s-dependencies",
-      "matchPackageNames": [
-        "sigs.k8s.io/**",
-        "!k8s.io/kubernetes",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.35.0"
-    },
-    {
       "matchManagers": ["gomod"],
       "groupName": "wrangler-lasso",
       "matchPackageNames": [
         "github.com/rancher/wrangler/v3",
         "github.com/rancher/lasso"
       ]
-    },
-    {
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "k8s.io/kubernetes",
-        "kubernetes/kubernetes",
-        "rancher/kubectl"
-      ],
-      "groupName": "gomod-k8s-dependencies",
-      "allowedVersions": "<1.35.0"
-    },
-    {
-      "matchPackageNames": [
-        "helm.sh/helm/v3"
-      ],
-      "groupName": "gomod-k8s-dependencies"
     },
     {
       "allowedVersions": "<15.8.0",
@@ -477,6 +447,7 @@
     {
       "description": "Group kubernetes/kubernetes and k8s.io/kubernetes",
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.35.0",
       "groupName": "Kubernetes dependencies",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
@@ -486,7 +457,12 @@
     },
     {
       "description": "Group other k8s.io dependencies with kubernetes/kubernetes",
-      "matchPackageNames": ["k8s.io/**"],
+      "matchPackageNames": [
+        "sigs.k8s.io/**",
+        "!k8s.io/kubernetes",
+        "k8s.io/**"
+      ],
+      "allowedVersions": "<0.35.0",
       "groupName": "Kubernetes dependencies"
     }
   ]

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -8,15 +8,19 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities",
+      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
+      "matchPackageNames": [
+        "!golang",
+        "!go",
+        "!registry.suse.com/bci/golang",
+        "!registry.opensuse.org/opensuse/bci/golang",
+        "!rancher/kubectl",
+        "!kubernetes/kubernetes",
+        "!k8s.io/**"
+      ],
+      "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability updates for test/dev dependencies",
-      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "enabled": false
     },
     {
       "description": "Enable patch updates for Go packages",
@@ -61,19 +65,6 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang",
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/**"
-      ],
-      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -8,15 +8,19 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities",
+      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
+      "matchPackageNames": [
+        "!golang",
+        "!go",
+        "!registry.suse.com/bci/golang",
+        "!registry.opensuse.org/opensuse/bci/golang",
+        "!rancher/kubectl",
+        "!kubernetes/kubernetes",
+        "!k8s.io/**"
+      ],
+      "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability updates for test/dev dependencies",
-      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "enabled": false
     },
     {
       "description": "Enable SLSACTL updates",
@@ -66,19 +70,6 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang",
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/**"
-      ],
-      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -8,15 +8,19 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities",
+      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
+      "matchPackageNames": [
+        "!golang",
+        "!go",
+        "!registry.suse.com/bci/golang",
+        "!registry.opensuse.org/opensuse/bci/golang",
+        "!rancher/kubectl",
+        "!kubernetes/kubernetes",
+        "!k8s.io/**"
+      ],
+      "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability updates for test/dev dependencies",
-      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "enabled": false
     },
     {
       "description": "Enable SLSACTL updates",
@@ -66,19 +70,6 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang",
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/**"
-      ],
-      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -8,15 +8,19 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities",
+      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
+      "matchPackageNames": [
+        "!golang",
+        "!go",
+        "!registry.suse.com/bci/golang",
+        "!registry.opensuse.org/opensuse/bci/golang",
+        "!rancher/kubectl",
+        "!kubernetes/kubernetes",
+        "!k8s.io/**"
+      ],
+      "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability updates for test/dev dependencies",
-      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "enabled": false
     },
     {
       "description": "Enable SLSACTL updates",
@@ -66,19 +70,6 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang",
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/**"
-      ],
-      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -8,15 +8,19 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities",
+      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
+      "matchPackageNames": [
+        "!golang",
+        "!go",
+        "!registry.suse.com/bci/golang",
+        "!registry.opensuse.org/opensuse/bci/golang",
+        "!rancher/kubectl",
+        "!kubernetes/kubernetes",
+        "!k8s.io/**"
+      ],
+      "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability updates for test/dev dependencies",
-      "matchDepTypes": ["devDependencies", "dev-dependencies", "test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "enabled": false
     },
     {
       "description": "Enable patch updates for Go packages",
@@ -61,19 +65,6 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
-    },
-    {
-      "description": "Disable vulnerability alerts for packages with patch-level updates to prevent minor/major version bumps",
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang",
-        "rancher/kubectl",
-        "kubernetes/kubernetes",
-        "k8s.io/**"
-      ],
-      "vulnerabilityAlerts": { "enabled": false }
     }
   ]
 }


### PR DESCRIPTION
- Simplified Kubernetes Grouping - Removed conflicting rules that were splitting k8s packages across separate prs
- Fixed slsactl GitHub Action Grouping - Added version constraints so action digest, version parameter, and version comments stay synchronized - Should prevent prs like these: https://github.com/rancher/fleet/pull/4437/changes
- Consolidate security vulnerability rules and exceptions

## Expected Changes summary

- There should be only one pr for Kubernetes bumps in the same branch (prs like https://github.com/rancher/fleet/pull/4440 should be part of https://github.com/rancher/fleet/pull/4444)
- There should be only one slsactl bump per branch and it also should always bump the version and the hash at the same time (prevent prs like these https://github.com/rancher/fleet/pull/4437)
- The Kubernetes pr should provide the version in its tile (prevent pr titles like https://github.com/rancher/fleet/pull/4444)
- There should be no Kubernetes prs for non-patch level bumps (prevent prs like https://github.com/rancher/rancher/pull/53116)