### PR TITLE
Add groupName for SLSACTL updates and Kubernetes

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -51,14 +51,16 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -25,7 +25,8 @@
     {
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "slsactl"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -57,14 +57,16 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -25,7 +25,8 @@
     {
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "slsactl"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -57,14 +57,16 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -25,7 +25,8 @@
     {
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "slsactl"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -57,14 +57,16 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -51,14 +51,16 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
       "matchUpdateTypes": ["patch"],
-      "enabled": true
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -28,7 +28,8 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "allowedVersions": "<1.36.0"
+      "allowedVersions": "<1.36.0",
+      "groupName": "Kubernetes dependencies"
     },
     {
       "matchManagers": [
@@ -44,7 +45,8 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.36.0"
+      "allowedVersions": "<0.36.0",
+      "groupName": "Kubernetes dependencies"
     }
   ]
 }


### PR DESCRIPTION
this should make sure that the tagged version and the action get updated at the same time.

It was already working on [main](https://github.com/rancher/fleet/pull/4423/changes) but not for release channels because of the missing groupName.

## Expected Changes summary

- The slsactl grouping should prevent release channel prs which only bump one part and not all versions like https://github.com/rancher/fleet/pull/4450. 
- The Kubernetes grouping should make sure Kubernetes prs are grouped together and also that the version is shown in the pr title - not like this pr https://github.com/rancher/rancher/pull/53121 where the version is missing