### PR TITLE
Restrict versions for SLSACTL  in release config

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -26,7 +26,8 @@
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
       "enabled": true,
-      "groupName": "slsactl"
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.10"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -26,7 +26,8 @@
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
       "enabled": true,
-      "groupName": "slsactl"
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.10"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -26,7 +26,8 @@
       "description": "Enable SLSACTL updates",
       "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
       "enabled": true,
-      "groupName": "slsactl"
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.10"
     },
     {
       "description": "Enable patch updates for Go packages",


### PR DESCRIPTION
to match the constraints of the SLSACTL default config grouping.

This should make sure that all version references are bumped in one pr.