### PR TITLE
Further small improvements

### DIFF
--- a/default.json
+++ b/default.json
@@ -454,13 +454,13 @@
     {
       "description": "Group kubernetes/kubernetes and k8s.io/kubernetes",
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.35.0",
+      "allowedVersions": "<1.35",
       "groupName": "Kubernetes dependencies",
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
-      "commitMessageExtra": "to {{#if newValue}}{{newValue}}{{else}}new patch version{{/if}}"
+      "commitMessageTopic": "Kubernetes dependencies to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}v{{newMajor}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{newDigestShort}}{{/if}}{{/if}}{{/if}}{{/if}}",
+      "commitMessageExtra": ""
     },
     {
       "description": "Group other k8s.io dependencies with kubernetes/kubernetes",
@@ -469,7 +469,7 @@
         "!k8s.io/kubernetes",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.35.0",
+      "allowedVersions": "<0.35",
       "groupName": "Kubernetes dependencies"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -442,8 +442,14 @@
     {
       "description": "Group slsactl GitHub Action (with digest)",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
-      "allowedVersions": "<=v0.1.10",
-      "groupName": "slsactl"
+      "groupName": "slsactl",
+      "matchUpdateTypes": ["pinDigest"]
+    },
+    {
+      "description": "Skip digest-only updates for slsactl GitHub Action",
+      "matchPackageNames": ["rancherlabs/slsactl/**"],
+      "matchUpdateTypes": ["digest"],
+      "enabled": false
     },
     {
       "description": "Group kubernetes/kubernetes and k8s.io/kubernetes",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -30,27 +30,27 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.32",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },
@@ -58,7 +58,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<0.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -4,6 +4,7 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false
     },
@@ -21,20 +22,6 @@
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Enable SLSACTL updates (version parameter)",
-      "matchPackageNames": ["rancherlabs/slsactl"],
-      "enabled": true,
-      "groupName": "slsactl",
-      "allowedVersions": "<=v0.1.10"
-    },
-    {
-      "description": "Enable SLSACTL updates (GitHub Action digest)",
-      "matchPackageNames": ["rancherlabs/slsactl/**"],
-      "enabled": true,
-      "groupName": "slsactl",
-      "allowedVersions": "<=v0.1.10"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -31,27 +31,27 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.33",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },
@@ -59,7 +59,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -31,27 +31,27 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.34",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },
@@ -59,7 +59,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -4,6 +4,7 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false
     },
@@ -21,20 +22,6 @@
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Enable SLSACTL updates (version parameter)",
-      "matchPackageNames": ["rancherlabs/slsactl"],
-      "enabled": true,
-      "groupName": "slsactl",
-      "allowedVersions": "<=v0.1.10"
-    },
-    {
-      "description": "Enable SLSACTL updates (GitHub Action digest)",
-      "matchPackageNames": ["rancherlabs/slsactl/**"],
-      "enabled": true,
-      "groupName": "slsactl",
-      "allowedVersions": "<=v0.1.10"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -31,27 +31,27 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.25",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.35",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },
@@ -59,7 +59,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -4,6 +4,7 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false
     },
@@ -21,20 +22,6 @@
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true
-    },
-    {
-      "description": "Enable SLSACTL updates (version parameter)",
-      "matchPackageNames": ["rancherlabs/slsactl"],
-      "enabled": true,
-      "groupName": "slsactl",
-      "allowedVersions": "<=v0.1.10"
-    },
-    {
-      "description": "Enable SLSACTL updates (GitHub Action digest)",
-      "matchPackageNames": ["rancherlabs/slsactl/**"],
-      "enabled": true,
-      "groupName": "slsactl",
-      "allowedVersions": "<=v0.1.10"
     },
     {
       "description": "Enable patch updates for Go packages",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -31,27 +31,27 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.35",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },
@@ -59,7 +59,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "vulnerabilityAlerts": { "enabled": true },
+  "packageRules": [
+    {
+      "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
+      "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
+      "enabled": false
+    },
+    {
+      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
+      "matchPackageNames": [
+        "!golang",
+        "!go",
+        "!registry.suse.com/bci/golang",
+        "!registry.opensuse.org/opensuse/bci/golang",
+        "!rancher/kubectl",
+        "!kubernetes/kubernetes",
+        "!k8s.io/**"
+      ],
+      "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "enabled": true
+    },
+    {
+      "description": "Enable patch updates for Go packages",
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Enable patch updates for golang-version datasource",
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Enable patch updates for kubectl",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true
+    },
+    {
+      "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
+    },
+    {
+      "description": "Enable patch updates for k8s.io dependencies",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "groupName": "Kubernetes dependencies"
+    },
+    {
+      "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",
+      "matchPackageNames": ["rancher/kuberlr-kubectl"],
+      "matchUpdateTypes": ["minor","patch"],
+      "enabled": true
+    }
+  ]
+}

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -30,27 +30,27 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.24",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.24",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.31",
       "enabled": true
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<1.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },
@@ -58,7 +58,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
-      "matchUpdateTypes": ["patch"],
+      "allowedVersions": "<0.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies"
     },


### PR DESCRIPTION
Reverting https://github.com/rancher/renovate-config/pull/611 because it did not work as expected because of the conflict between the default.json `allowedVersions` and `matchUpdateTypes`.

## Expected Changes summary

* SLSACTL bumps should be properly grouped now and restricted to the version specified in default.json
* Patch-level dependency updates (Go and Kubernetes) will now be created again
* Kubernetes and Go patches will be properly constrained to their respective version limits per release branch
* A rancher-2.14.json was introduced which can be used for Rancher sub projects.