### PR TITLE
Fix remaining issues

### DIFF
--- a/default.json
+++ b/default.json
@@ -459,8 +459,8 @@
       "semanticCommitType": "chore",
       "semanticCommitScope": "deps",
       "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}v{{newMajor}}{{else}}{{#if isSingleVersion}}{{newVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{newDigestShort}}{{/if}}{{/if}}{{/if}}{{/if}}",
-      "commitMessageExtra": ""
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Group other k8s.io dependencies with kubernetes/kubernetes",
@@ -476,7 +476,12 @@
         "k8s.io/**"
       ],
       "allowedVersions": "<0.35",
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -467,6 +467,12 @@
       "matchPackageNames": [
         "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
       "allowedVersions": "<0.35",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -69,7 +69,12 @@
       ],
       "allowedVersions": "<0.32",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -57,7 +57,16 @@
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
       "allowedVersions": "<0.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -58,7 +58,16 @@
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
       "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -70,7 +70,12 @@
       ],
       "allowedVersions": "<0.33",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -70,7 +70,12 @@
       ],
       "allowedVersions": "<0.34",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -58,7 +58,16 @@
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
       "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies"

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -58,7 +58,16 @@
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies"

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -70,7 +70,12 @@
       ],
       "allowedVersions": "<0.35",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -58,7 +58,16 @@
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies"

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -70,7 +70,12 @@
       ],
       "allowedVersions": "<0.35",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -57,7 +57,16 @@
     {
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["!k8s.io/kubernetes", "k8s.io/**"],
+      "matchPackageNames": [
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
       "allowedVersions": "<0.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies"

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -69,7 +69,12 @@
       ],
       "allowedVersions": "<0.31",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable minor and patch updates for rancher/kuberlr-kubectl",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -46,7 +46,12 @@
         "k8s.io/**"
       ],
       "allowedVersions": "<0.36.0",
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     }
   ]
 }


### PR DESCRIPTION
## Expected Changes Summary
* Do not bump k8s digest based versions anymore (e.g. https://github.com/rancher/fleet/pull/4517) - we had exceptions for those in the past but they were removed when switching to patch level bumps
* Add Version Information to Kubernetes Dependencies PR Titles - the issue is that there are often different versions in one pr