### PR TITLE
Further kubernetes improvements

### DIFF
--- a/default.json
+++ b/default.json
@@ -456,10 +456,7 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.35",
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -477,10 +474,7 @@
       ],
       "allowedVersions": "<0.35",
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     }
   ]

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -16,6 +16,7 @@
         "!registry.opensuse.org/opensuse/bci/golang",
         "!rancher/kubectl",
         "!kubernetes/kubernetes",
+        "!k8s.io/kubernetes",
         "!k8s.io/**"
       ],
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -53,10 +53,7 @@
       "allowedVersions": "<1.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -75,10 +72,7 @@
       "allowedVersions": "<0.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -52,7 +52,12 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.32",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -54,10 +54,7 @@
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -76,10 +73,7 @@
       "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -53,7 +53,12 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.33",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -17,6 +17,7 @@
         "!registry.opensuse.org/opensuse/bci/golang",
         "!rancher/kubectl",
         "!kubernetes/kubernetes",
+        "!k8s.io/kubernetes",
         "!k8s.io/**"
       ],
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -53,7 +53,12 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.34",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -54,10 +54,7 @@
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -76,10 +73,7 @@
       "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -17,6 +17,7 @@
         "!registry.opensuse.org/opensuse/bci/golang",
         "!rancher/kubectl",
         "!kubernetes/kubernetes",
+        "!k8s.io/kubernetes",
         "!k8s.io/**"
       ],
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -53,7 +53,12 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.35",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -17,6 +17,7 @@
         "!registry.opensuse.org/opensuse/bci/golang",
         "!rancher/kubectl",
         "!kubernetes/kubernetes",
+        "!k8s.io/kubernetes",
         "!k8s.io/**"
       ],
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -54,10 +54,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -76,10 +73,7 @@
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -53,7 +53,12 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.35",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -17,6 +17,7 @@
         "!registry.opensuse.org/opensuse/bci/golang",
         "!rancher/kubectl",
         "!kubernetes/kubernetes",
+        "!k8s.io/kubernetes",
         "!k8s.io/**"
       ],
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -54,10 +54,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -76,10 +73,7 @@
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -16,6 +16,7 @@
         "!registry.opensuse.org/opensuse/bci/golang",
         "!rancher/kubectl",
         "!kubernetes/kubernetes",
+        "!k8s.io/kubernetes",
         "!k8s.io/**"
       ],
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -52,7 +52,12 @@
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.31",
       "enabled": true,
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Enable patch updates for k8s.io dependencies",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -53,10 +53,7 @@
       "allowedVersions": "<1.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -75,10 +72,7 @@
       "allowedVersions": "<0.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -29,7 +29,12 @@
         "k8s.io/kubernetes"
       ],
       "allowedVersions": "<1.36.0",
-      "groupName": "Kubernetes dependencies"
+      "groupName": "Kubernetes dependencies",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps",
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "matchManagers": [

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -30,10 +30,7 @@
       ],
       "allowedVersions": "<1.36.0",
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -52,10 +49,7 @@
       ],
       "allowedVersions": "<0.36.0",
       "groupName": "Kubernetes dependencies",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps",
-      "commitMessageAction": "update",
-      "commitMessageTopic": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     }
   ]


### PR DESCRIPTION
Even though the Kubernetes prs are grouped together, both seem to require the commit message parameters, otherwise the first kubernetes entry used defines the commit message and pr title.

I have also removed the chore dep part, because the title is already more then long enough.

I have also disabled security updates for k8s.io/kubernetes explicitly, to hopefully prevent prs like these: https://github.com/rancher/rancher/pull/53308
This should be covered by the regular Kubernetes dependency bumping.