### PR TITLE
Remove 'Update' from Kubernetes commitMessageTopic

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -54,7 +54,7 @@
       "allowedVersions": "<1.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -73,7 +73,7 @@
       "allowedVersions": "<0.32",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -55,7 +55,7 @@
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -74,7 +74,7 @@
       "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -55,7 +55,7 @@
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -74,7 +74,7 @@
       "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -55,7 +55,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -74,7 +74,7 @@
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -55,7 +55,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -74,7 +74,7 @@
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -54,7 +54,7 @@
       "allowedVersions": "<1.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -73,7 +73,7 @@
       "allowedVersions": "<0.31",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -30,7 +30,7 @@
       ],
       "allowedVersions": "<1.36.0",
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
@@ -49,7 +49,7 @@
       ],
       "allowedVersions": "<0.36.0",
       "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     }
   ]


### PR DESCRIPTION
Renovate's commitMessageAction defaults to 'Update', and the PR title template includes spaces between components.

Result: PR titles will now show 'Update Kubernetes dependencies to v...' instead of '[Update Update Kubernetes dependencies to v...](https://github.com/rancher/rancher/pull/53331)'