### PR TITLE
Provide minimum BCI image version

### DIFF
--- a/default.json
+++ b/default.json
@@ -336,10 +336,11 @@
       ]
     },
     {
-      "allowedVersions": "<15.8.0",
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
       "matchPackageNames": [
-        "/^registry.suse.com/bci/bci/",
-        "/^registry.suse.com/suse/sle15/"
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
       ]
     },
     {


### PR DESCRIPTION
to make sure that the referenced images are still maintained and receive updates.

For example 15.6 images are not maintained anymore. Until now they have to be bumped manually in the release branches.

It should prevent manual bumps like [these](https://github.com/rancher/fleet/pull/4543/changes/928b66cd4f22b85aeed87e6b9836195d26f8cc8e).