### PR TITLE
Remove constraints on slsactl versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -437,7 +437,6 @@
     {
       "description": "Group and restrict rancherlabs/slsactl (GitHub tag and version parameter)",
       "matchPackageNames": ["rancherlabs/slsactl"],
-      "allowedVersions": "<=v0.1.10",
       "groupName": "slsactl"
     },
     {


### PR DESCRIPTION
This is blocking new PRs across the ecosystem.