### PR TITLE
Constraint slsactl bumps for Rancher-aligned projects

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -81,6 +81,11 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.20"
     }
   ]
 }

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -82,6 +82,11 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.20"
     }
   ]
 }

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -82,6 +82,11 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.20"
     }
   ]
 }

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -82,6 +82,11 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.20"
     }
   ]
 }

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -81,6 +81,11 @@
       "matchPackageNames": ["rancher/kuberlr-kubectl"],
       "matchUpdateTypes": ["minor","patch"],
       "enabled": true
+    },
+    {
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.20"
     }
   ]
 }

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -51,6 +51,11 @@
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
+    },
+    {
+      "matchPackageNames": ["rancherlabs/slsactl"],
+      "groupName": "slsactl",
+      "allowedVersions": "<=v0.1.20"
     }
   ]
 }


### PR DESCRIPTION
This aims to provide stability and decrease the amount of bumps for project that have to keep up with several release lines.