### PR TITLE
Bump Go to at least version 1.25

### DIFF
--- a/default.json
+++ b/default.json
@@ -359,6 +359,20 @@
       "allowedVersions": "<1.26.0"
     },
     {
+      "description": "Group Go and toolchain minor bumps into one PR",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor"],
+      "matchDatasources": ["golang-version"],
+      "groupName": "Go toolchain"
+    },
+    {
+      "description": "Bump go directive on minor Go releases",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "rangeStrategy": "bump",
+      "groupName": "Go toolchain"
+    },
+    {
       "allowedVersions": "<1.0.0",
       "matchPackageNames": [
         "rancher/dapper"

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -32,13 +32,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -32,13 +32,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -32,13 +32,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -32,13 +32,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {
       "description": "Enable patch updates for golang-version datasource",
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.25",
+      "allowedVersions": "<1.26",
       "enabled": true
     },
     {


### PR DESCRIPTION
- Bump Go `allowedVersions` to `<1.26` on release branches
- Group go+toolchain minor bumps into one PR