### PR TITLE
Group go+toolchain minor bumps, disable patch bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -373,6 +373,13 @@
       "groupName": "Go toolchain"
     },
     {
+      "description": "Disable patch bumps for go directive",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
       "allowedVersions": "<1.0.0",
       "matchPackageNames": [
         "rancher/dapper"


### PR DESCRIPTION
Together with [pr](https://github.com/rancher/renovate-config/pull/670) add three packageRules to default.json for the go directive in go.mod files. The go directive uses go-mod-directive versioning which treats it as a range (^1.25), so rangeStrategy: bump is required to propose minor version updates at all.

Two rules to enable and group minor bumps:
- matchUpdateTypes minor + matchDatasources golang-version: puts both go and toolchain minor updates into one grouped PR
- matchDepTypes golang + rangeStrategy bump: enables Renovate to actually propose updates to the go directive (disabled by default) and groups it with the toolchain update under "Go toolchain"

One rule to block patch bumps:
- matchDepTypes golang + matchUpdateTypes patch + enabled false: prevents PRs like go 1.25.0 -> 1.25.8 which are useless since go mod tidy will raise the go directive automatically when a dependency requires a newer patch version anyway