### PR TITLE
Stop bumping go directive via Renovate

### DIFF
--- a/default.json
+++ b/default.json
@@ -366,20 +366,6 @@
       "groupName": "Go toolchain"
     },
     {
-      "description": "Bump go directive on minor Go releases",
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["golang"],
-      "rangeStrategy": "bump",
-      "groupName": "Go toolchain"
-    },
-    {
-      "description": "Disable patch bumps for go directive",
-      "matchManagers": ["gomod"],
-      "matchDepTypes": ["golang"],
-      "matchUpdateTypes": ["patch"],
-      "enabled": false
-    },
-    {
       "allowedVersions": "<1.0.0",
       "matchPackageNames": [
         "rancher/dapper"


### PR DESCRIPTION
Remove the `rangeStrategy: bump` rule and the patch-disable workaround rule for the `go` directive in `go.mod` files.

When `rangeStrategy: bump` was active, Renovate bumped the `go` directive to the latest patch version in the target minor series (e.g. `go 1.25.8`, not `go 1.25.0`). After the bump, `go` and `toolchain` were identical, so `go mod tidy` immediately removed the `toolchain` line — making the bump self-defeating. The patch-disable rule was a workaround to block the useless patch PRs, but is no longer needed.

The rule also broke `go.work` files. Go 1.21+ requires the `go` directive in `go.work` to be >= all workspace module `go` directives. When `go.mod` jumped to `go 1.25.8`, the `go.work` file became invalid and `go get -t ./...` failed. Renovate has no built-in `postUpdateOption` for `go work use`, so the artifact update always errored out.

Renovate's own documentation recommends not bumping the `go` directive unless necessary; the default behavior is to leave it alone. The `toolchain` directive already conveys what Go version is used for building and continues to be updated by Renovate automatically (both patch and minor). After a minor `toolchain` bump PR, the state will be `go 1.24.0` plus `toolchain go1.25.8`: minimum API compat 1.24, built with 1.25.8. The `go` directive advances only when `go mod tidy` requires it because a dependency needs a newer version.

Only the grouping rule for minor `toolchain` bumps under "Go toolchain" remains.

To prevent prs like [this one](https://github.com/rancher/fleet/pull/4784/changes).