### PR TITLE
Group outdated golangci-lint with Go bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -160,6 +160,18 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.ya?ml/"
+      ],
+      "matchStrings": [
+        "uses:\\s*golangci/golangci-lint-action@[^\\n]+[\\s\\S]*?version:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/"
       ],
@@ -364,6 +376,15 @@
       "matchUpdateTypes": ["minor"],
       "matchDatasources": ["golang-version"],
       "groupName": "Go toolchain"
+    },
+    {
+      "description": "Group outdated golangci-lint workflow versions with Go minor bumps",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": [".github/workflows/**"],
+      "matchPackageNames": ["golangci/golangci-lint"],
+      "matchCurrentVersion": "<2.4.0",
+      "groupName": "Go toolchain",
+      "minimumGroupSize": 2
     },
     {
       "allowedVersions": "<1.0.0",


### PR DESCRIPTION
Add a regex custom manager for `.github/workflows/*.yml` files to extract the `version:` input used by
`golangci/golangci-lint-action`. The existing
`golangci/golangci-lint` extraction only covered Dockerfiles and Makefiles, so workflow-pinned linter binaries were invisible to Renovate.

Add a package rule that matches `golangci/golangci-lint` only in workflow files and only when the current version is below `2.4.0`. Those outdated workflow versions are grouped into the existing `Go toolchain` branch and `minimumGroupSize: 2` prevents a standalone linter PR.

This means repositories get one PR when a Go toolchain minor bump would otherwise break CI because the workflow linter is too old, while repositories already on `>=2.4.0` continue to receive only the Go update. The change lives in the shared preset, so release branch configs inherit it without duplicating rules in the `rancher-2.x.json` files.