### PR TITLE
Exempt slsactl from minimumReleaseAge

### DIFF
--- a/default.json
+++ b/default.json
@@ -442,6 +442,11 @@
       ]
     },
     {
+      "description": "Exempt slsactl from minimumReleaseAge to allow immediate pickup",
+      "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
+      "minimumReleaseAge": "0 days"
+    },
+    {
       "description": "Group and restrict rancherlabs/slsactl (GitHub tag and version parameter)",
       "matchPackageNames": ["rancherlabs/slsactl"],
       "groupName": "slsactl",


### PR DESCRIPTION
Add a packageRule in `default.json` that sets `minimumReleaseAge` to `0 days` for `rancherlabs/slsactl` and `rancherlabs/slsactl/**`, so updates are picked up immediately after release without waiting for the global 5-day delay, as long as they satisfy the active `allowedVersions` constraint.

The package is internally maintained, bumps for it are restricted by version and if we increase the version restraint we might have to fix an immediate issue.