### PR TITLE
Add envtest data for renovate-local

### DIFF
--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -46,6 +46,20 @@ kubectl_save_arch_sources() {
     done
 }
 
+envtest_fetch_data() {
+    curl --retry 3 --retry-connrefused -L https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/HEAD/envtest-releases.yaml > "${DATA_DIR}/envtest-data.yaml"
+}
+
+envtest_save_arch_sources() {
+    local OSES=("linux" "darwin")
+    for os in "${OSES[@]}"; do
+        for arch in "${ARCHS[@]}"; do
+            yq e -o=json '.releases | to_entries | .[] | .key as $version | .value | to_entries | .[] | select(.key == "envtest-" + $version + "-'"${os}"'-'"${arch}"'.tar.gz") | { "version": $version, "digest": .value.hash }' "${DATA_DIR}/envtest-data.yaml" | \
+            jq -s '{ "releases": . | sort_by(.version) | reverse }' > "${DATA_DIR}/envtest-${os}-${arch}.json"
+        done
+    done
+}
+
 main() {
     mkdir -p "${DATA_DIR}"
 
@@ -57,6 +71,8 @@ main() {
         kustomize_save_arch_sources
         kubectl_fetch_data
         kubectl_save_arch_sources
+        envtest_fetch_data
+        envtest_save_arch_sources
     fi
 }
 


### PR DESCRIPTION
I want to be able to download envtest with checksum, I need the following change to make this snippet work with renovate:

```sh
# renovate-local: envtest-linux-amd64
ENVTEST_VERSION=v1.35.0
# renovate-local: envtest-linux-amd64=v1.35.0
ENVTEST_SUM_linux_amd64=130369c16f076e724d089189afaede960316f5f5dea6cf57be7a4fc6f09c77342893192509790e4056e116e232dff832ed863f5bd55dcb55d38f3ab834828a11
# renovate-local: envtest-linux-arm64=v1.35.0
ENVTEST_SUM_linux_arm64=e53e2b88398f5b9503e3f074d82a2dcb090c708b34940848607ce658138a5d4a25962e042ab683ccc026a8a6c90c0be7f658e42dde0887369d73c3b68e2fc86c
# renovate-local: envtest-darwin-amd64=v1.35.0
ENVTEST_SUM_darwin_amd64=fccc583ba6d322c88a8c56f7876090a7ad63460046a4bcae414093b23ce68a75f172ca7484b7c7475b707657eca5108a8ad3fd85e1b4f70a6c99ca2f22dbd6b2
# renovate-local: envtest-darwin-arm64=v1.35.0
ENVTEST_SUM_darwin_arm64=bb5d0bb3975956331b0aa0c039955b4c4dc6c5c288e5af369364c7d2fbeac11a025227dabb127569080b259dd29b697cc77fa77abd27ae26721ddb23e8ee0613

```

~~This also fixes an issue with kubectl where not all files are downloaded (missing the arch-specific files due to casing)~~ fixed in another PR

Here's the PR that would make use of that: https://github.com/rancher/steve/pull/1077