### PR TITLE
Increase minimum release age

### DIFF
--- a/default.json
+++ b/default.json
@@ -318,7 +318,7 @@
         "github-actions"
       ],
       "allowedVersions": "<2.8.0",
-      "minimumReleaseAge": "14 days"
+      "minimumReleaseAge": "28 days"
     },
     {
       "matchPackageNames": [
@@ -383,7 +383,7 @@
         "action"
       ],
       "pinDigests": true,
-      "minimumReleaseAge": "14 days"
+      "minimumReleaseAge": "28 days"
     },
     {
       "matchPackageNames": [

--- a/default.json
+++ b/default.json
@@ -13,7 +13,7 @@
   ],
   "automergeStrategy": "merge-commit",
   "prConcurrentLimit": 0,
-  "minimumReleaseAge": "5 days",
+  "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "constraints": {
     "go": "<1.26"


### PR DESCRIPTION
* Increase `minimumReleaseAge` for Github Actions to `28 days` because it does take the release date into account but the commit so you can get pull requests for releases which are only three days old (like this [one](https://github.com/rancher/fleet/pull/4924)), because their release process took so long.

  Real vetting most likely only happens after the release so we should increase it.

  Security bumps are an exception of the `minimumReleaseAge` so we should not loose anything by doing so.
  
  Renovate can only handle the release age, if a real semver version is provided behind the pinned digest, it does not work with major versions only or without a comment. I will look into adapting our pinning script that it provides the correct semver if there is one.

* Increase minimumReleaseAge for non-github actions to 7 days because 5 seemed very low, especially considering that it is commit based. At the same time the risk for them is much lower then Github actions because bumps will only be part of the current Rancher development version, long before release.
