### PR TITLE
Fixes kubectl file generation

### DIFF
--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -36,7 +36,7 @@ kustomize_save_arch_sources() {
 }
 
 kubectl_save_arch_sources() {
-    for arch in "${archs[@]}"; do
+    for arch in "${ARCHS[@]}"; do
           grep "linux_${arch}" "${DATA_DIR}/kubectl-data.raw" | jq -n --raw-input --slurp '{ "releases": [
             inputs | split("\n")[]
             | select(test("^\\w+\\s+kubectl_"))


### PR DESCRIPTION
Before:

```
# tree data/
data/
├── kubectl-data.raw
├── kustomize-amd64.json
├── kustomize-arm64.json
├── kustomize-data.raw
└── kustomize-s390x.json
```

After:

```
# tree data/
data/
├── kubectl-amd64.json
├── kubectl-arm64.json
├── kubectl-data.raw
├── kubectl-s390x.json
├── kustomize-amd64.json
├── kustomize-arm64.json
├── kustomize-data.raw
└── kustomize-s390x.json
```