### PR TITLE
Add more files to renovate/renovate-local and allow yaml A: B

### DIFF
--- a/default.json
+++ b/default.json
@@ -288,22 +288,27 @@
         "/(^|/)Dockerfile[^/]*$/",
         "/(^|/)Makefile$/",
         "/hack/make/deps.mk/",
-        "/scripts/.*\\.sh$/"
+        "/scripts/.*\\.sh$/",
+        "/(^|/)\\.github/.*\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*=(\\s|\"|)(?<currentValue>.*)(\"|)",
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*=(\\s|\"|)(?<currentDigest>.*)(\"|)"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*[:=](\\s|\"|)(?<currentDigest>.*)(\"|)"
       ]
     },
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/(^|/|\\.)Dockerfile$/",
+        "/(^|/)Dockerfile[^/]*$/",
         "/(^|/)Makefile$/",
-        "/hack/make/deps.mk/"
+        "/hack/make/deps.mk/",
+        "/scripts/.*\\.sh$/",
+        "/(^|/)\\.github/.*\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*=(\\s|\"|)(?<currentValue>.*)(\"|)",
-        "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*=(\\s|\"|)(?<currentDigest>.*)(\"|)"
+        "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*[:=](\\s|\"|)(?<currentDigest>.*)(\"|)"
       ],
       "datasourceTemplate": "custom.local"
     }


### PR DESCRIPTION
1. The files for `# renovate-local:` and `# renovate:` are pretty limited. I'm expanding that.
2. We're currently not matching the following:

```yaml
    steps:
      - name: Checkout repository
        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

      - name: Install helm
        env:
          # renovate: datasource=github-release-attachments depName=helm/helm
          HELM_VERSION: "v3.13.3"
          # renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v3.13.3
          HELM_CHECKSUM_sha256: "bbb6e7c6201458b235f335280f35493950dcd856825ddcfd1d3b40ae757d5c7d"
```

for example for GHA files. So let's allow this.