### PR TITLE
Pin deployed workflow ref to latest semver tag

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -66,7 +66,26 @@ jobs:
             git add .github/renovate.json
           fi
 
+          STATIC_SHA="f62bbe9fec9bef07a9f15addc2f9c6ea278ac736"
+          STATIC_TAG="v1.0.0"
+          LATEST_TAG=$(gh api repos/rancher/renovate-config/tags \
+            --jq '[.[].name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | first' 2>/dev/null || true)
+          if [ -n "${LATEST_TAG}" ] && [ "${LATEST_TAG}" != "null" ]; then
+            TAG_OBJ=$(gh api "repos/rancher/renovate-config/git/refs/tags/${LATEST_TAG}" 2>/dev/null || true)
+            TAG_SHA=$(echo "${TAG_OBJ}" | jq -r '.object.sha // empty')
+            TAG_TYPE=$(echo "${TAG_OBJ}" | jq -r '.object.type // empty')
+            if [ "${TAG_TYPE}" = "tag" ]; then
+              TAG_SHA=$(gh api "repos/rancher/renovate-config/git/tags/${TAG_SHA}" \
+                --jq '.object.sha // empty' 2>/dev/null || true)
+            fi
+          fi
+          if [ -z "${TAG_SHA}" ] || [ "${TAG_SHA}" = "null" ]; then
+            TAG_SHA="${STATIC_SHA}"
+            LATEST_TAG="${STATIC_TAG}"
+          fi
           cp ../main/files/renovate-vault.yml .github/workflows/renovate-vault.yml
+          sed -i "s|/.github/workflows/renovate-vault.yml@release|/.github/workflows/renovate-vault.yml@${TAG_SHA} # ${LATEST_TAG}|" \
+            .github/workflows/renovate-vault.yml
           git add .github/workflows/renovate-vault.yml
           FILES_TO_REMOVE=".github/dependabot.yaml .github/dependabot.yml .github/workflows/renovate.yml"
           for FILE_TO_REMOVE in $FILES_TO_REMOVE; do


### PR DESCRIPTION
The deploy action previously copied `renovate-vault.yml` verbatim, leaving the `uses:` line in deployed repos pointing at `@release` (a mutable branch ref). The action now resolves the latest semver tag from `rancher/renovate-config` via the GitHub API, dereferences it to a commit SHA (handling both lightweight and annotated tags), and patches that SHA into the deployed file. If the API call fails, it falls back to `f62bbe9fec9bef07a9f15addc2f9c6ea278ac736 # v1.0.0`.