### PR TITLE
Use baseBranchPatterns in deploy workflow

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -7,9 +7,9 @@ on:
         required: true
         default: "rancher/"
         type: string
-permissions: 
+permissions:
   id-token: write
-  
+
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Set owner and repositories values
         id: set_values
-        run: | 
+        run: |
           owner=$(echo "${{ github.event.inputs.deployRepository }}" | cut -d '/' -f1)
           repositories=$(echo "${{ github.event.inputs.deployRepository }}" | cut -d '/' -f2)
           echo "owner=$owner" >> "$GITHUB_OUTPUT"
@@ -59,8 +59,8 @@ jobs:
           git checkout -b "${BRANCH}"
           mkdir -p .github/workflows
           TEMP_CONFIG=$(mktemp)
-          jq --arg default_branch "${DEFAULT_BRANCH}" '.baseBranches = [$default_branch]' ../main/files/renovate.json > "${TEMP_CONFIG}"
-          
+          jq --arg default_branch "${DEFAULT_BRANCH}" '.baseBranchPatterns = [$default_branch]' ../main/files/renovate.json > "${TEMP_CONFIG}"
+
           if [ ! -f .github/renovate.json ]; then
             mv "${TEMP_CONFIG}" .github/renovate.json
             git add .github/renovate.json


### PR DESCRIPTION
The deploy workflow's `jq` command was writing the deprecated `baseBranches` field into every deployed `renovate.json`, even though the template already uses `baseBranchPatterns`. This caused Renovate to open a "migrate Renovate config" PR in every newly onboarded repository (as seen in rancher/fleet-helm-charts#290).