### PR TITLE
Fix minimumReleaseAge override, vulnerability alert delay, Go 1.26, and validate

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -39,11 +39,6 @@ on:
         required: false
         default: "null"
         type: string
-      extendsPreset:
-        description: "Override renovate extends preset (default: 'github>rancher/renovate-config#release')."
-        required: false
-        default: "github>rancher/renovate-config#release"
-        type: string
     secrets:
       override-token:
         description: "Overrides the GH App Token. Use this to run from forks which don't have access to the GH App."
@@ -72,8 +67,6 @@ env:
   # https://docs.renovatebot.com/configuration-options/#configmigration
   RENOVATE_CONFIG_MIGRATION: ${{ inputs.configMigration || 'true' }}
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || 'null' }}
-  # Override renovate extends preset if set
-  RENOVATE_EXTENDS_PRESET: ${{ inputs.extendsPreset || 'github>rancher/renovate-config#release' }}
 
 permissions:
   contents: read

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -72,8 +72,6 @@ env:
   # https://docs.renovatebot.com/configuration-options/#configmigration
   RENOVATE_CONFIG_MIGRATION: ${{ inputs.configMigration || 'true' }}
   RENOVATE_DRY_RUN: ${{ inputs.dryRun || 'null' }}
-  # Override minimumReleaseAge if set
-  RENOVATE_MINIMUM_RELEASE_AGE: ${{ inputs.minimumReleaseAge != 'null' && inputs.minimumReleaseAge || '' }}
   # Override renovate extends preset if set
   RENOVATE_EXTENDS_PRESET: ${{ inputs.extendsPreset || 'github>rancher/renovate-config#release' }}
 
@@ -123,6 +121,17 @@ jobs:
           private-key: ${{ env.PRIVATE_KEY }}
       - name: Generate custom data sources
         run: ./renovate-config/hack/generate-data-sources.sh
+      - name: Override minimumReleaseAge in RENOVATE_FORCE
+        if: inputs.minimumReleaseAge != 'null'
+        env:
+          MINIMUM_RELEASE_AGE: ${{ inputs.minimumReleaseAge }}
+        run: |
+          CURRENT="${RENOVATE_FORCE:-}"
+          if [[ -z "$CURRENT" ]]; then
+            CURRENT='{}'
+          fi
+          MERGED=$(printf '%s' "$CURRENT" | jq --arg age "$MINIMUM_RELEASE_AGE" '. + {"minimumReleaseAge": $age}')
+          echo "RENOVATE_FORCE=$MERGED" >> "$GITHUB_ENV"
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
         with:

--- a/default.json
+++ b/default.json
@@ -4,6 +4,9 @@
     "mergeConfidence:age-confidence-badges"
   ],
   "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "2 days"
+  },
   "baseBranchPatterns": [
     "main"
   ],

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -36,11 +36,6 @@ on:
         required: false
         default: "null"
         type: string
-      extendsPreset:
-        description: "Override renovate extends preset (default: 'github>rancher/renovate-config#release')."
-        required: false
-        default: "github>rancher/renovate-config#release"
-        type: string
 
   schedule:
     - cron: '30 4,6 * * 1-5'
@@ -58,6 +53,5 @@ jobs:
       overrideSchedule: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
       renovateConfig: ${{ inputs.renovateConfig || '.github/renovate.json' }}
       minimumReleaseAge: ${{ inputs.minimumReleaseAge || 'null' }}
-      extendsPreset: ${{ inputs.extendsPreset || 'github>rancher/renovate-config#release' }}
     secrets:
       override-token: "${{ secrets.RENOVATE_FORK_GH_TOKEN || '' }}"

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -9,13 +9,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.26.0"
+      "allowedVersions": "<1.27.0"
     },
     {
       "matchDatasources": [
         "golang-version"
       ],
-      "allowedVersions": "<1.26.0"
+      "allowedVersions": "<1.27.0"
     },
     {
       "matchManagers": [

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["{{#if env.RENOVATE_EXTENDS_PRESET}}{{env.RENOVATE_EXTENDS_PRESET}}{{else}}github>rancher/renovate-config#release{{/if}}"],
+  "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
- All `rancher-2.x.json` and `rancher-main.json` files had a Handlebars template in `extends` that `renovate-config-validator --strict` rejects now (previously validator versions did not) as an invalid preset name; this is replaced with the static default `github>rancher/renovate-config#release`. The `extendsPreset` workflow input and `RENOVATE_EXTENDS_PRESET` env var are removed from both workflow files — the template that consumed them no longer exists, and `RENOVATE_EXTENDS_PRESET` was never a recognized Renovate self-hosted env var.
- `RENOVATE_MINIMUM_RELEASE_AGE` is not a Renovate env var; `minimumReleaseAge`  is a repository-level option that requires `RENOVATE_FORCE` to override. The  non-functional env var is removed and replaced with a step that merges the input  value into `RENOVATE_FORCE` with `jq`, preserving any existing value (e.g. a  schedule override set in the same run).
- `vulnerabilityAlerts.minimumReleaseAge` is set to `2 days` in `default.json` so  Renovate proposes CVE fixes with a short delay rather than the standard 7-day wait.
- `rancher-main.json` Go and golang-version `allowedVersions` raised to `<1.27.0`  to permit Go 1.26 in Rancher v2.15.
  
Supersedes #702 