### PR TITLE
Fix RENOVATE_FORCE assembly for schedule and age overrides

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -59,8 +59,6 @@ env:
   RENOVATE_GIT_AUTHOR: "renovate-rancher <119870437+renovate-rancher[bot]@users.noreply.github.com>"
   # Use GitHub API to create commits (this allows for signed commits from GitHub App)
   RENOVATE_PLATFORM_COMMIT: "true"
-  # Override schedule if set
-  RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{''schedule'':null}' || '' }}
   # Override loglevel if set
   LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
   RENOVATE_CONFIG_FILE: ${{ inputs.renovateConfig || '.github/renovate.json' }}
@@ -114,17 +112,21 @@ jobs:
           private-key: ${{ env.PRIVATE_KEY }}
       - name: Generate custom data sources
         run: ./renovate-config/hack/generate-data-sources.sh
-      - name: Override minimumReleaseAge in RENOVATE_FORCE
-        if: inputs.minimumReleaseAge != 'null'
+      - name: Assemble RENOVATE_FORCE
         env:
+          OVERRIDE_SCHEDULE: ${{ github.event.inputs.overrideSchedule }}
           MINIMUM_RELEASE_AGE: ${{ inputs.minimumReleaseAge }}
         run: |
-          CURRENT="${RENOVATE_FORCE:-}"
-          if [[ -z "$CURRENT" ]]; then
-            CURRENT='{}'
+          FORCE='{}'
+          if [[ "$OVERRIDE_SCHEDULE" == 'true' ]]; then
+            FORCE=$(printf '%s' "$FORCE" | jq -c '. + {"schedule": null}')
           fi
-          MERGED=$(printf '%s' "$CURRENT" | jq --arg age "$MINIMUM_RELEASE_AGE" '. + {"minimumReleaseAge": $age}')
-          echo "RENOVATE_FORCE=$MERGED" >> "$GITHUB_ENV"
+          if [[ -n "$MINIMUM_RELEASE_AGE" && "$MINIMUM_RELEASE_AGE" != 'null' ]]; then
+            FORCE=$(printf '%s' "$FORCE" | jq -c --arg age "$MINIMUM_RELEASE_AGE" '. + {"minimumReleaseAge": $age}')
+          fi
+          if [[ "$FORCE" != '{}' ]]; then
+            echo "RENOVATE_FORCE=$FORCE" >> "$GITHUB_ENV"
+          fi
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@0b17c4eb901eca44d018fb25744a50a74b2042df # v46.1.4
         with:


### PR DESCRIPTION
`jq` without `-c` produces indented multiline JSON. Writing that to `GITHUB_ENV` via `echo "KEY=VALUE"` fails because the file format requires the value on a single line; each subsequent indented line is parsed as a new entry and rejected. Separately, the env-level `RENOVATE_FORCE` used a GitHub Actions string literal `{'schedule':null}` with single quotes, which is not valid JSON and would make `jq` fail when both `overrideSchedule` and `minimumReleaseAge` are set simultaneously.

The env-level `RENOVATE_FORCE` is removed and replaced with a single step that builds valid compact JSON from scratch using `jq -c`, handles neither, one, or both overrides, and only writes to `GITHUB_ENV` when the result is non-empty.

[Successful test run with different minimalReleaseAge](https://github.com/rancher/fleet/actions/runs/24348123213/job/71094593359).