### PR TITLE
Keep deprecated extendsPreset input for backward compat

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -39,6 +39,11 @@ on:
         required: false
         default: "null"
         type: string
+      extendsPreset:
+        description: "Deprecated: no longer used. Kept for backward compatibility with older deployed workflows."
+        required: false
+        default: ""
+        type: string
     secrets:
       override-token:
         description: "Overrides the GH App Token. Use this to run from forks which don't have access to the GH App."


### PR DESCRIPTION
Consumer repos deployed before e969193 still pass `extendsPreset` via `with:` in their local copy of `files/renovate-vault.yml`. GitHub Actions rejects the `workflow_call` when the callee no longer declares that input, causing "Invalid input, extendsPreset is not defined in the referenced workflow" errors in those consumers.

Restore `extendsPreset` as an optional, unused input so existing callers keep working until they update their local workflow copy.