### PR TITLE
Add 2-day release age for renovate-config GH Actions deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -511,6 +511,12 @@
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
+    },
+    {
+      "description": "Update renovate-vault workflow references quickly after release",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["rancher/renovate-config", "rancher/renovate-config/**"],
+      "minimumReleaseAge": "2 days"
     }
   ]
 }

--- a/files/renovate-vault.yml
+++ b/files/renovate-vault.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@d71b40c949ef761985760fed6d195493b805ef42 # v1.0.1
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@release
     with:
       configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}


### PR DESCRIPTION
Consumer repos deploy `files/renovate-vault.yml` as their `.github/workflows/renovate-vault.yml`. Once deployed, the default github-actions manager in each consumer repo already tracks the `rancher/renovate-config` tag reference there. Adding a `packageRule` with `minimumReleaseAge: 2 days` for `rancher/renovate-config` github-actions deps (overriding the 28-day default) ensures consumers pick up new workflow versions within 2 days.

**Bumping the Renovate action only works efficiently when the according semver version is in the comment behind the pinned digest.**

Restores `@release` in `files/renovate-vault.yml`: `renovate-deploy.yml` resolves the latest tag SHA at deploy time and substitutes it with `sed`. The file previously held a hardcoded SHA, causing the sed substitution to silently no-op and new deployments to receive an outdated SHA.