### PR TITLE
Track KUBECTL_VERSION in Dockerfiles and shell scripts

### DIFF
--- a/default.json
+++ b/default.json
@@ -75,7 +75,7 @@
         "/\\.sh$/"
       ],
       "matchStrings": [
-        "KUBECTL_VERSION=\"\\$\\{KUBECTL_VERSION:-(?<currentValue>[^}]+)\\}\""
+        "KUBECTL_VERSION=\"\\$\\{KUBECTL_VERSION:-(?<currentValue>[^}\\r\\n]+)\\}\""
       ],
       "depNameTemplate": "kubernetes/kubernetes",
       "datasourceTemplate": "github-releases"

--- a/default.json
+++ b/default.json
@@ -72,6 +72,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/\\.sh$/"
+      ],
+      "matchStrings": [
+        "KUBECTL_VERSION=\"\\$\\{KUBECTL_VERSION:-(?<currentValue>[^}]+)\\}\""
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/",
         "/hack/make/deps.mk/"

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.32",
       "enabled": true,

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.33",
       "enabled": true,

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.34",
       "enabled": true,

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.35",
       "enabled": true,

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.36",
       "enabled": true,

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -53,7 +53,7 @@
     },
     {
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod"],
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
       "allowedVersions": "<1.31",
       "enabled": true,


### PR DESCRIPTION
Consumer repos set `KUBECTL_VERSION` in three ways: `ENV KUBECTL_VERSION=…` and `ARG KUBECTL_VERSION=…` in Dockerfiles, and `KUBECTL_VERSION="${KUBECTL_VERSION:-…}"` as a bash default value in shell scripts. The first two forms were already detected by an existing custom.regex manager entry; the shell-script form was not covered and is added here.

- All `rancher-2.x` presets had the `kubernetes/kubernetes` package rule limited to `gomod` in `matchManagers`, so `KUBECTL_VERSION` bumps detected by the `custom.regex` and `dockerfile` managers were silently disabled on release branches. `custom.regex` and `dockerfile` are added to that rule in every release preset.

Followup to allow Renovate to automate prs like this: https://github.com/rancher/rancher/pull/54595