### PR TITLE
Update deploy script to replace any reference format

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -84,7 +84,7 @@ jobs:
             LATEST_TAG="${STATIC_TAG}"
           fi
           cp ../main/files/renovate-vault.yml .github/workflows/renovate-vault.yml
-          sed -i "s|/.github/workflows/renovate-vault.yml@release|/.github/workflows/renovate-vault.yml@${TAG_SHA} # ${LATEST_TAG}|" \
+          sed -i -E "s~/.github/workflows/renovate-vault.yml@(release|[a-f0-9]{40})( # .*)?~/.github/workflows/renovate-vault.yml@${TAG_SHA} # ${LATEST_TAG}~" \
             .github/workflows/renovate-vault.yml
           git add .github/workflows/renovate-vault.yml
           FILES_TO_REMOVE=".github/dependabot.yaml .github/dependabot.yml .github/workflows/renovate.yml"


### PR DESCRIPTION
Use regex to match and replace any `renovate-vault.yml` reference format:
- `@release` (current template placeholder)
- `@<40-hex-sha>` (pinned SHA without comment, from older deployments)
- `@<40-hex-sha> # <version>` (pinned SHA with version comment, from older deployments)

The pin-gha script did also change the `files/renovate-vault.yml`, which required the following [fix](https://github.com/rancher/renovate-config/pull/711/changes/c7d47264817ab308e2b9df297e6ab24a8e2daf3c).
With this change it should not matter if the file was updated or not, it should always be deployed with the latest semver version.
