### PR TITLE
Fix digest regex: trailing quote and missing suffixes

### DIFF
--- a/default.json
+++ b/default.json
@@ -307,7 +307,7 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>.*)(\"|)",
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*[:=](\\s|\"|)(?<currentDigest>.*)(\"|)"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ]
     },
     {
@@ -333,7 +333,7 @@
       ],
       "matchStrings": [
         "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>.*)(\"|)",
-        "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x).*[:=](\\s|\"|)(?<currentDigest>.*)(\"|)"
+        "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ],
       "datasourceTemplate": "custom.local"
     }


### PR DESCRIPTION
The greedy `.*` in the `currentDigest` capture group consumed the closing quote of shell variable assignments like `VAR="<hash>"`, so Renovate stored `<hash>"` (with trailing quote) as the digest. When `getDigest` scanned the checksums file for a matching line, the comparison always failed and the checksum variable was left unchanged even though the `digestVersion` comment was bumped correctly. This affected `crust-gather` (#5033), `k3d`, and `goreleaser` (#4946).

Replacing `.*` with `[^"\\s]*` stops the capture before the closing quote. The variable-name suffix alternation is also extended with `x86_64`, `SUM`, and `CHECKSUM` to cover variables like `GORELEASER_CHECKSUM_x86_64` and `RANCHER_CLI_SUM` that were previously not matched at all.

Should fix https://github.com/rancher/fleet/pull/5033/changes and https://github.com/rancher/fleet/pull/4946/changes