### PR TITLE
Clean up default.json and bump Kubernetes/BCI for Rancher 2.15

### DIFF
--- a/default.json
+++ b/default.json
@@ -396,12 +396,6 @@
       "groupName": "Go toolchain"
     },
     {
-      "allowedVersions": "<1.0.0",
-      "matchPackageNames": [
-        "rancher/dapper"
-      ]
-    },
-    {
       "groupName": "GitHub Actions",
       "matchManagers": [
         "github-actions"

--- a/default.json
+++ b/default.json
@@ -499,7 +499,7 @@
       "description": "Group kubectl, kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.36",
+      "allowedVersions": "<1.37.0",
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
@@ -518,7 +518,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.36",
+      "allowedVersions": "<0.37.0",
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"

--- a/default.json
+++ b/default.json
@@ -389,14 +389,6 @@
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
-      "description": "Restrict BCI images to maintained versions only",
-      "allowedVersions": "<15.8",
-      "matchPackageNames": [
-        "/^registry\\.suse\\.com\\/bci\\//",
-        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
-      ]
-    },
-    {
       "description": "Group Go and toolchain minor bumps into one PR",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor"],

--- a/default.json
+++ b/default.json
@@ -366,6 +366,32 @@
       ]
     },
     {
+      "description": "Group kubectl, kubernetes/kubernetes and k8s.io/kubernetes",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "groupName": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
+    },
+    {
+      "description": "Group other k8s.io and sigs.k8s.io dependencies",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "sigs.k8s.io/**",
+        "!k8s.io/kubernetes",
+        "!k8s.io/gengo",
+        "!k8s.io/gengo/**",
+        "!k8s.io/utils",
+        "!k8s.io/utils/**",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/kube-openapi/**",
+        "k8s.io/**"
+      ],
+      "groupName": "Kubernetes dependencies",
+      "commitMessageTopic": "Update Kubernetes dependencies",
+      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<15.8",
       "matchPackageNames": [
@@ -494,34 +520,6 @@
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["digest"],
       "enabled": false
-    },
-    {
-      "description": "Group kubectl, kubernetes/kubernetes and k8s.io/kubernetes",
-      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["rancher/kubectl", "kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.37.0",
-      "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
-      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
-    },
-    {
-      "description": "Group other k8s.io dependencies with kubernetes/kubernetes",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": [
-        "sigs.k8s.io/**",
-        "!k8s.io/kubernetes",
-        "!k8s.io/gengo",
-        "!k8s.io/gengo/**",
-        "!k8s.io/utils",
-        "!k8s.io/utils/**",
-        "!k8s.io/kube-openapi",
-        "!k8s.io/kube-openapi/**",
-        "k8s.io/**"
-      ],
-      "allowedVersions": "<0.37.0",
-      "groupName": "Kubernetes dependencies",
-      "commitMessageTopic": "Update Kubernetes dependencies",
-      "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
     {
       "description": "Update renovate-vault workflow references quickly after release",

--- a/default.json
+++ b/default.json
@@ -18,9 +18,6 @@
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
-  "constraints": {
-    "go": "<1.26"
-  },
   "postUpdateOptions": [
     "gomodTidy",
     "gomodUpdateImportPaths"
@@ -398,21 +395,6 @@
         "/^registry\\.suse\\.com\\/bci\\//",
         "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
       ]
-    },
-    {
-      "matchPackageNames": [
-        "golang",
-        "go",
-        "registry.suse.com/bci/golang",
-        "registry.opensuse.org/opensuse/bci/golang"
-      ],
-      "allowedVersions": "<1.26.0"
-    },
-    {
-      "matchDatasources": [
-        "golang-version"
-      ],
-      "allowedVersions": "<1.26.0"
     },
     {
       "description": "Group Go and toolchain minor bumps into one PR",

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -4,6 +4,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false

--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -65,6 +65,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -4,6 +4,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -65,6 +65,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -4,6 +4,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -65,6 +65,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -4,6 +4,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -65,6 +65,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -4,6 +4,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -65,6 +65,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -4,6 +4,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<15.8",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "enabled": false

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -65,6 +65,7 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -28,7 +28,7 @@
         "kubernetes/kubernetes",
         "k8s.io/kubernetes"
       ],
-      "allowedVersions": "<1.36.0",
+      "allowedVersions": "<1.37.0",
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
@@ -47,7 +47,7 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.36.0",
+      "allowedVersions": "<0.37.0",
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -3,6 +3,14 @@
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {
+      "description": "Restrict BCI images to maintained versions only",
+      "allowedVersions": "<16.1",
+      "matchPackageNames": [
+        "/^registry\\.suse\\.com\\/bci\\//",
+        "/^registry\\.suse\\.com\\/suse\\/sle15\\//"
+      ]
+    },
+    {
       "matchPackageNames": [
         "golang",
         "go",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -38,6 +38,7 @@
         "gomod"
       ],
       "matchPackageNames": [
+        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",


### PR DESCRIPTION
- Bumps the Kubernetes `allowedVersions` ceiling to 1.36/0.36 in `rancher-main.json` for Rancher 2.15.
- Removes Kubernetes and Go constraints from `default.json` that were redundant with per-preset rules.
- Moves the BCI ceiling into each preset file so it can be set independently per release line.
- Raises the BCI ceiling in `rancher-main.json` to `<16.1` to allow SLE 16.0 images.