### PR TITLE
Remove sigs.k8s.io from release preset re-enablement rules

### DIFF
--- a/rancher-2.10.json
+++ b/rancher-2.10.json
@@ -73,7 +73,6 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -73,7 +73,6 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -73,7 +73,6 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -73,7 +73,6 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -73,7 +73,6 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",

--- a/rancher-2.9.json
+++ b/rancher-2.9.json
@@ -73,7 +73,6 @@
       "description": "Enable patch updates for k8s.io dependencies",
       "matchManagers": ["gomod"],
       "matchPackageNames": [
-        "sigs.k8s.io/**",
         "!k8s.io/kubernetes",
         "!k8s.io/gengo",
         "!k8s.io/gengo/**",


### PR DESCRIPTION
Each `rancher-2.x` preset disables all updates by default and explicitly re-enables specific packages. Adding `sigs.k8s.io/**` to the k8s.io re-enablement rules in those files (introduced in #719) caused Renovate to propose incompatible minor-version bumps for `sigs.k8s.io/controller-runtime`, `sigs.k8s.io/controller-tools`, and `sigs.k8s.io/kustomize/*` on all release branches.

- `sigs.k8s.io/controller-runtime` versions as `v0.2x.y`, not `v0.3x.y`, so the `allowedVersions: "<0.3x"` ceiling does not constrain it — Renovate sees v0.23.x as satisfying `<0.35` and proposes the latest available. The `default.json` grouping rule continues to cover `sigs.k8s.io/**` for naming and grouping on main-branch consumers; `rancher-main.json` retains the explicit ceiling there.