### PR TITLE
Fix version regex stripping closing quote from assignments

### DIFF
--- a/default.json
+++ b/default.json
@@ -303,7 +303,7 @@
         "/(^|/)\\.github/.*\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ]
     },
@@ -329,7 +329,7 @@
         "/(^|/)\\.github/.*\\.ya?ml$/"
       ],
       "matchStrings": [
-        "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>.*)(\"|)",
+        "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
         "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ],
       "datasourceTemplate": "custom.local"


### PR DESCRIPTION
The VERSION pattern used a greedy `.*` for `currentValue`, which consumed the closing quote of shell variable assignments like `VAR="v1.2.3"`. Renovate stored `v1.2.3"` as `currentValue` and when writing the bump substituted that string with the new version, producing `VAR="v0.14.1` with no closing quote. This was visible in https://github.com/rancher/fleet/pull/5033 after the digest fix in #718.

Replace `.*` with `[^\"\\s]*` in both the `renovate:` and `renovate-local:` VERSION patterns, applying the same fix that was already applied to the digest patterns in #718.