### PR TITLE
Group ginkgo with gomega in gomod updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -484,6 +484,12 @@
       "minimumGroupSize": 2
     },
     {
+      "description": "Group ginkgo and gomega together as ginkgo bumps gomega",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
+      "groupName": "ginkgo and gomega"
+    },
+    {
       "description": "Skip digest-only updates for slsactl GitHub Action",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["digest"],


### PR DESCRIPTION
Ginkgo bumps gomega as a transitive dependency, so separate PRs for each are redundant (fleet#5079, fleet#5080). Group them so Renovate creates a single PR for both.