### PR TITLE
feat: add minimumGroupSize: 5 to k8s.io dependency group

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -56,6 +56,7 @@
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -66,6 +67,7 @@
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -85,6 +87,7 @@
       "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -56,6 +56,7 @@
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -66,6 +67,7 @@
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -85,6 +87,7 @@
       "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -56,6 +56,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -66,6 +67,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -85,6 +87,7 @@
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -56,6 +56,7 @@
       "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -66,6 +67,7 @@
       "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -85,6 +87,7 @@
       "allowedVersions": "<0.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -38,6 +38,7 @@
       ],
       "allowedVersions": "<1.37.0",
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -58,6 +59,7 @@
       ],
       "allowedVersions": "<0.37.0",
       "groupName": "Kubernetes dependencies",
+      "minimumGroupSize": 5,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },


### PR DESCRIPTION
Prevents partial Kubernetes bumps where only a few `k8s.io/**` packages are released at a time. Renovate will now only open the PR once at least 5 packages in the group are available, matching the full Kubernetes release cadence.

- Apply `minimumGroupSize: 5` to all three rules sharing `groupName: "Kubernetes dependencies"` (kubectl, kubernetes/kubernetes, and k8s.io/**) to ensure consistent threshold enforcement regardless of which update Renovate processes first for the group.

Should prevent PRs like: rancher/fleet#5110