### PR TITLE
Fix slsactl version-field regex to match annotation comment

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,7 +47,7 @@
         "/\\.github/workflows/.*\\.ya?ml/"
       ],
       "matchStrings": [
-        ".*?- uses:\\s*rancherlabs/slsactl/actions/install-slsactl@.*?\\s*with:\\s*(?:[^\\n]*\\n\\s*)*?version:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
+        "# renovate: datasource=github-tags depName=rancherlabs/slsactl\\n\\s*version:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "rancherlabs/slsactl",
       "datasourceTemplate": "github-tags"


### PR DESCRIPTION
The custom regex manager for the slsactl `version:` field had two bugs. The `.*?- uses: rancherlabs/slsactl...` prefix does not span newlines, so it never matched steps that open with `- name:` ([Fleet's format](https://github.com/rancher/fleet/blob/main/.github/workflows/release.yml#L83-L87)). Even for `- uses:` steps, the matched block contained the version string twice — once in the `# vX.Y.Z` comment on the `uses:` line and once in `version:` — causing Renovate to replace the comment occurrence rather than the `version:` field.

`rancherlabs/slsactl` publishes only git tags, not GitHub Releases, so the regex now matches only `datasource=github-tags`, consistent with `datasourceTemplate: "github-tags"`.