### PR TITLE
Group golang.org/x/ gomod packages into one PR

### DIFF
--- a/default.json
+++ b/default.json
@@ -490,6 +490,12 @@
       "groupName": "ginkgo and gomega"
     },
     {
+      "description": "Group golang.org/x/ packages together as they release in sync and go get forces co-updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "groupName": "golang.org/x dependencies"
+    },
+    {
       "description": "Skip digest-only updates for slsactl GitHub Action",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["digest"],


### PR DESCRIPTION
The `golang.org/x/` packages (`net`, `crypto`, `sys`, `term`, `text`, etc.) share a coordinated release cycle and `go get` forces all of them to update together when any one is bumped. Without a grouping rule, Renovate opens a separate PR per package in the same run; each PR carries the same artifact updates as the others, making them redundant and conflicting on merge (as seen with rancher/fleet#5136 and rancher/fleet#5135).

Adding a `packageRule` grouping `golang.org/x/**` gomod packages under a single `groupName` causes Renovate to batch all co-available updates into one PR.