### PR TITLE
Allow Wrangler, lasso and Go runtime bumps after three days

### DIFF
--- a/default.json
+++ b/default.json
@@ -398,6 +398,26 @@
       "groupName": "Go toolchain"
     },
     {
+      "description": "Allow Go runtime updates after 3 days to get security releases faster",
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "Allow Go Docker image updates after 3 days to get security releases faster",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "groupName": "GitHub Actions",
       "matchManagers": [
         "github-actions"

--- a/default.json
+++ b/default.json
@@ -355,12 +355,14 @@
       "groupName": "renovate-bumps"
     },
     {
+      "description": "Allow Wrangler and lasso updates to be created after 3 days because they are internal products",
       "matchManagers": ["gomod"],
       "groupName": "wrangler-lasso",
       "matchPackageNames": [
         "github.com/rancher/wrangler/v3",
         "github.com/rancher/lasso"
-      ]
+      ],
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Group kubectl, kubernetes/kubernetes and k8s.io/kubernetes",


### PR DESCRIPTION
Reduce `minimumReleaseAge` from 7 days to 3 days for two groups of dependencies:

### Wrangler and lasso

`github.com/rancher/wrangler` and `github.com/rancher/lasso` are internal
Rancher libraries. There is no meaningful risk in picking up a new release
quickly, so waiting a full week adds unnecessary latency.

### Go runtime

Go security releases (e.g. patch releases like 1.24.3) frequently do not carry
an explicit CVE or security advisory at the time they are published. Waiting
7 days means we can miss the window to include the fix in the next product
release. Reducing to 3 days covers:

- The `go`/`toolchain` directive in `go.mod` files (`golang-version` datasource)
- Docker `golang` and BCI golang base images (`docker` datasource)

This mirrors the two-rule pattern already used in the per-branch configs
(`rancher-main.json`, `rancher-2.x.json`), which keep the two datasources
separated because Docker images and the `golang-version` datasource are
distinct in Renovate.