### PR TITLE
Group golang.org/x/ vulnerability PRs into the shared group

### DIFF
--- a/default.json
+++ b/default.json
@@ -518,6 +518,13 @@
       "groupName": "golang.org/x dependencies"
     },
     {
+      "description": "Group golang.org/x/ vulnerability fixes into the same group to avoid sys artifact conflicts",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "groupName": "golang.org/x dependencies"
+    },
+    {
       "description": "Skip digest-only updates for slsactl GitHub Action",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["digest"],


### PR DESCRIPTION
Renovate's vulnerability alert code path creates `-vulnerability` branches independently of `packageRules.groupName`, which caused separate security PRs for `golang.org/x/crypto` and `golang.org/x/net` that both carried `golang.org/x/sys` as an artifact update — conflicting on merge. A prior rule grouped regular `golang.org/x` updates but did not affect vulnerability PRs.

Renovate does evaluate `packageRules` entries that filter via `matchJsonata: ["$exists(vulnerabilityFixVersion)"]` during vulnerability processing. Adding the same `groupName` there routes security-triggered `golang.org/x` updates onto the shared group branch alongside regular updates.

Refers rancher/fleet#5189
Refers rancher/fleet#5190