### PR TITLE
Fix golang.org/x vulnerability grouping by grouping all current security bumps together

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,8 @@
   ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "minimumReleaseAge": "2 days"
+    "minimumReleaseAge": "2 days",
+    "groupName": "security"
   },
   "baseBranchPatterns": [
     "main"
@@ -515,13 +516,6 @@
       "description": "Group golang.org/x/ packages together as they release in sync and go get forces co-updates",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["golang.org/x/**"],
-      "groupName": "golang.org/x dependencies"
-    },
-    {
-      "description": "Group golang.org/x/ vulnerability fixes into the same group to avoid sys artifact conflicts",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["golang.org/x/**"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "groupName": "golang.org/x dependencies"
     },
     {


### PR DESCRIPTION
Renovate injects a `force` block for every vulnerability alert that explicitly sets `groupName: null`, overriding all `packageRules` regardless of their priority or filters (including `matchJsonata`). The `matchJsonata`-based rule added in the previous attempt was therefore ineffective dead code and has been removed. The only way to override this is through the top-level `vulnerabilityAlerts` config, whose fields are merged directly into the `force` block.

Adding `groupName: "security"` there routes all security-triggered updates onto one shared branch per base branch, preventing the `golang.org/x/sys` artifact conflict that occurs when `golang.org/x/crypto` and `golang.org/x/net` CVEs are published simultaneously.

Refers rancher/fleet#5189
Refers rancher/fleet#5190
Refers rancher/fleet#5196