### PR TITLE
Disable major/minor split for vulnerability alert groups

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,8 @@
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "2 days",
-    "groupName": "security"
+    "groupName": "security",
+    "separateMajorMinor": false
   },
   "baseBranchPatterns": [
     "main"

--- a/default.json
+++ b/default.json
@@ -6,7 +6,7 @@
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "2 days",
-    "groupName": "security",
+    "groupName": "vulnerable packages",
     "separateMajorMinor": false
   },
   "baseBranchPatterns": [


### PR DESCRIPTION
When `separateMajorMinor` is true (Renovate's default), a named vulnerability alert group is split into two branches: one for minor/patch bumps (`renovate/main-security`) and one for major bumps (`renovate/main-major-security`). This caused two concurrent security group PRs against the same base branch.

E. g.:
* https://github.com/rancher/rancher/pull/55338
* https://github.com/rancher/rancher/pull/55339

Setting `separateMajorMinor: false` in `vulnerabilityAlerts` ensures all vulnerability alert updates land in a single branch regardless of semver bump magnitude, the same way the `force` block groups them.

Also change groupName to "vulnerable packages" to prevent the duplication of the term `security`. The title should be in the future something like: `Update vulnerable packages [SECURITY] (main)`

Listing packages in the title is not possible with grouped prs to my knowledge.

As an alternative we can revert https://github.com/rancher/renovate-config/pull/741/, which might be the better solution if we activate autoMerge in Renovate, because then the merge conflicts would be resolved by Renovate over time I suppose.


We can either go for this pr or improving reverting the security grouping with #744.