### PR TITLE
Revert "Fix golang.org/x vulnerability grouping via vulnerabilityAlerts"

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,8 +5,7 @@
   ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "minimumReleaseAge": "2 days",
-    "groupName": "security"
+    "minimumReleaseAge": "2 days"
   },
   "baseBranchPatterns": [
     "main"
@@ -516,6 +515,13 @@
       "description": "Group golang.org/x/ packages together as they release in sync and go get forces co-updates",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["golang.org/x/**"],
+      "groupName": "golang.org/x dependencies"
+    },
+    {
+      "description": "Group golang.org/x/ vulnerability fixes into the same group to avoid sys artifact conflicts",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "groupName": "golang.org/x dependencies"
     },
     {

--- a/default.json
+++ b/default.json
@@ -518,13 +518,6 @@
       "groupName": "golang.org/x dependencies"
     },
     {
-      "description": "Group golang.org/x/ vulnerability fixes into the same group to avoid sys artifact conflicts",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["golang.org/x/**"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "groupName": "golang.org/x dependencies"
-    },
-    {
       "description": "Skip digest-only updates for slsactl GitHub Action",
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["digest"],


### PR DESCRIPTION
to prevent the grouping of most security bumps in one pr with a non-explanatory title.

This reverts commit 736d11d0dc69660f4c04d9ab4f55a8227c13607c.

~~We can either go for this pr or improving the security group with [#743](https://github.com/rancher/renovate-config/pull/743).~~

Decided to go back to the original behavior of having multiple security prs, to have better release notes, and the merge conflict issues should be solved in the future by letting Renovate merge the prs and rebase the failing prs during its next run.

