### PR TITLE
Automatically update kubectl checksums

### DIFF
--- a/default.json
+++ b/default.json
@@ -296,6 +296,34 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/(^|/|\\.)Dockerfile$/",
+        "/(^|/)Dockerfile[^/]*$/"
+      ],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>[^\\r\\n\\s]+)\\n[\\s\\S]*",
+        "ENV KUBECTL_CHECKSUM_amd64(\\=|\\s)(?<currentDigest>[^\\r\\n\\s]+)\\n"
+      ],
+      "depNameTemplate": "kubectl-amd64",
+      "datasourceTemplate": "custom.local"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/|\\.)Dockerfile$/",
+        "/(^|/)Dockerfile[^/]*$/"
+      ],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>[^\\r\\n\\s]+)\\n[\\s\\S]*",
+        "ENV KUBECTL_CHECKSUM_arm64(\\=|\\s)(?<currentDigest>[^\\r\\n\\s]+)\\n"
+      ],
+      "depNameTemplate": "kubectl-arm64",
+      "datasourceTemplate": "custom.local"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/",
         "/(^|/)Makefile$/",
         "/hack/make/deps.mk/",
@@ -365,9 +393,9 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Group kubectl, kubernetes/kubernetes and k8s.io/kubernetes",
+      "description": "Group kubectl version and checksum dependencies with kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["rancher/kubectl", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "matchPackageNames": ["rancher/kubectl", "kubernetes/kubernetes", "k8s.io/kubernetes", "kubectl-amd64", "kubectl-arm64"],
       "groupName": "Kubernetes dependencies",
       "commitMessageTopic": "Update Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -93,14 +93,14 @@ main() {
     kubectl_fetch_data
     kubectl_save_arch_sources
   fi
-  if grep -r -q --exclude-dir=renovate-config "# renovate-local: kustomize" ./; then
+  if grep -r -q --exclude-dir=renovate-config --exclude-dir=.git --exclude-dir="${DATA_DIR}" "# renovate-local: kustomize" ./; then
     kustomize_fetch_data
     kustomize_save_arch_sources
   fi
-  if grep -r -q --exclude-dir=renovate-config "# renovate-local: goreleaser" ./; then
+  if grep -r -q --exclude-dir=renovate-config --exclude-dir=.git --exclude-dir="${DATA_DIR}" "# renovate-local: goreleaser" ./; then
     goreleaser_fetch_data
   fi
-  if grep -r -q --exclude-dir=renovate-config "# renovate-local: ghcli" ./; then
+  if grep -r -q --exclude-dir=renovate-config --exclude-dir=.git --exclude-dir="${DATA_DIR}" "# renovate-local: ghcli" ./; then
     ghcli_fetch_data
   fi
 }

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -87,9 +87,9 @@ main() {
   mkdir -p "${DATA_DIR}"
 
   # Only fetch custom data in projects where they are used.
-  # For projects where "# renovate-local" is not applied, skip this
-  # process altogether.
-  if grep -r -q --exclude-dir=renovate-config "# renovate-local: kubectl" ./; then
+  # For kubectl, also enable this when checksum variables are present,
+  # even if "# renovate-local" is not applied.
+  if grep -r -q --exclude-dir=renovate-config --exclude-dir=.git --exclude-dir="${DATA_DIR}" -e "# renovate-local: kubectl" -e "KUBECTL_CHECKSUM_amd64" -e "KUBECTL_CHECKSUM_arm64" ./; then
     kubectl_fetch_data
     kubectl_save_arch_sources
   fi

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -52,7 +52,7 @@
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["rancher/kubectl"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -52,7 +52,7 @@
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["rancher/kubectl"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -52,7 +52,7 @@
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["rancher/kubectl"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -52,7 +52,7 @@
     {
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
-      "matchPackageNames": ["rancher/kubectl"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
       "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -34,7 +34,9 @@
       "matchPackageNames": [
         "rancher/kubectl",
         "kubernetes/kubernetes",
-        "k8s.io/kubernetes"
+        "k8s.io/kubernetes",
+        "kubectl-amd64",
+        "kubectl-arm64"
       ],
       "allowedVersions": "<1.37.0",
       "groupName": "Kubernetes dependencies",


### PR DESCRIPTION
Add Renovate regex managers to extract kubectl checksum dependencies from Dockerfiles using the existing KUBECTL_VERSION context. Extend Kubernetes package rules in active presets so kubectl checksum dependencies are enabled, grouped, and version-constrained together with other Kubernetes bumps.

Trigger kubectl custom datasource generation when KUBECTL_CHECKSUM_amd64 or KUBECTL_CHECKSUM_arm64 variables are present, even without renovate-local annotations.

Should make future Kubernetes bumps like https://github.com/rancher/rancher/pull/54651 work out of the box by also updating the checksum.