### PR TITLE
Harden kubectl custom datasource updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -74,8 +74,8 @@
       "matchStrings": [
         "KUBECTL_VERSION=\"\\$\\{KUBECTL_VERSION:-(?<currentValue>[^}\\r\\n]+)\\}\""
       ],
-      "depNameTemplate": "kubernetes/kubernetes",
-      "datasourceTemplate": "github-releases"
+      "depNameTemplate": "kubectl-amd64",
+      "datasourceTemplate": "custom.local"
     },
     {
       "customType": "regex",

--- a/default.json
+++ b/default.json
@@ -63,8 +63,8 @@
         "KUBECTL_VERSION.*\\=\\s*(?<currentValue>.*?)\\n",
         "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"
       ],
-      "depNameTemplate": "kubernetes/kubernetes",
-      "datasourceTemplate": "github-releases"
+      "depNameTemplate": "kubectl-amd64",
+      "datasourceTemplate": "custom.local"
     },
     {
       "customType": "regex",

--- a/default.json
+++ b/default.json
@@ -59,6 +59,7 @@
         "/(^|/)Dockerfile[^/]*$/",
         "/hack/make/deps.mk/"
       ],
+      "description": "Canonical kubectl version source for Dockerfile and deps files; tied to custom.local so version bumps only happen when checksum data is available",
       "matchStrings": [
         "KUBECTL_VERSION.*\\=\\s*(?<currentValue>.*?)\\n",
         "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"
@@ -71,6 +72,7 @@
       "managerFilePatterns": [
         "/\\.sh$/"
       ],
+      "description": "Canonical kubectl version source for shell scripts; tied to custom.local so version bumps only happen when checksum data is available",
       "matchStrings": [
         "KUBECTL_VERSION=\"\\$\\{KUBECTL_VERSION:-(?<currentValue>[^}\\r\\n]+)\\}\""
       ],
@@ -298,6 +300,7 @@
         "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/"
       ],
+      "description": "Arch-specific checksum manager for kubectl amd64 in Dockerfiles",
       "matchStringsStrategy": "recursive",
       "matchStrings": [
         "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>[^\\r\\n\\s]+)\\n[\\s\\S]*",
@@ -312,6 +315,7 @@
         "/(^|/|\\.)Dockerfile$/",
         "/(^|/)Dockerfile[^/]*$/"
       ],
+      "description": "Arch-specific checksum manager for kubectl arm64 in Dockerfiles",
       "matchStringsStrategy": "recursive",
       "matchStrings": [
         "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>[^\\r\\n\\s]+)\\n[\\s\\S]*",

--- a/default.json
+++ b/default.json
@@ -64,7 +64,8 @@
         "KUBECTL_VERSION.*\\=\\s*(?<currentValue>.*?)\\n",
         "ENV KUBECTL_VERSION(\\=|\\s)(?<currentValue>.*?)\\n"
       ],
-      "depNameTemplate": "kubectl-amd64",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "packageNameTemplate": "kubectl-amd64",
       "datasourceTemplate": "custom.local"
     },
     {
@@ -76,7 +77,8 @@
       "matchStrings": [
         "KUBECTL_VERSION=\"\\$\\{KUBECTL_VERSION:-(?<currentValue>[^}\\r\\n]+)\\}\""
       ],
-      "depNameTemplate": "kubectl-amd64",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "packageNameTemplate": "kubectl-amd64",
       "datasourceTemplate": "custom.local"
     },
     {

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -77,7 +77,8 @@ kubectl_save_arch_sources() {
     grep "linux_${arch}" "${DATA_DIR}/kubectl-data.raw" | jq -n --raw-input --slurp '{ "releases": [
             inputs | split("\n")[]
             | select(test("^\\w+\\s+kubectl_"))
-            | match("(?<digest>\\w+)\\s+kubectl_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")
+            | (match("(?<digest>\\w+)\\s+kubectl_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")?)
+            | select(. != null)
             | { version: ("\(.captures[1].string)"), digest: .captures[0].string }
           ]}' >"${DATA_DIR}/kubectl-${arch}.json"
   done
@@ -85,6 +86,7 @@ kubectl_save_arch_sources() {
 
 main() {
   mkdir -p "${DATA_DIR}"
+  rm -f "${DATA_DIR}/kubectl-data.raw" "${DATA_DIR}/kustomize-data.raw"
 
   # Only fetch custom data in projects where they are used.
   # For kubectl, also enable this when checksum variables are present,

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -66,7 +66,7 @@ kustomize_save_arch_sources() {
     grep "linux_${arch}" "${DATA_DIR}/kustomize-data.raw" | jq -n --raw-input --slurp '{ "releases": [
             inputs | split("\n")[]
             | select(test("^\\w+\\s+kustomize_"))
-            | (match("(?<digest>\\w+)\\s+kustomize_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")?)
+            | match("(?<digest>\\w+)\\s+kustomize_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")
             | select(. != null)
             | { version: ("\(.captures[1].string)"), digest: .captures[0].string }
           ]}' >"${DATA_DIR}/kustomize-${arch}.json"
@@ -78,7 +78,7 @@ kubectl_save_arch_sources() {
     grep "linux_${arch}" "${DATA_DIR}/kubectl-data.raw" | jq -n --raw-input --slurp '{ "releases": [
             inputs | split("\n")[]
             | select(test("^\\w+\\s+kubectl_"))
-            | (match("(?<digest>\\w+)\\s+kubectl_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")?)
+            | match("(?<digest>\\w+)\\s+kubectl_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")
             | select(. != null)
             | { version: ("\(.captures[1].string)"), digest: .captures[0].string }
           ]}' >"${DATA_DIR}/kubectl-${arch}.json"
@@ -90,9 +90,9 @@ main() {
   rm -f "${DATA_DIR}/kubectl-data.raw" "${DATA_DIR}/kustomize-data.raw"
 
   # Only fetch custom data in projects where they are used.
-  # For kubectl, also enable this when checksum variables are present,
+  # For kubectl, also enable this when KUBECTL_VERSION/checksum variables are present,
   # even if "# renovate-local" is not applied.
-  if grep -r -q --exclude-dir=renovate-config --exclude-dir=.git --exclude-dir="${DATA_DIR}" -e "# renovate-local: kubectl" -e "KUBECTL_CHECKSUM_amd64" -e "KUBECTL_CHECKSUM_arm64" ./; then
+  if grep -r -q --exclude-dir=renovate-config --exclude-dir=.git --exclude-dir="${DATA_DIR}" -e "# renovate-local: kubectl" -e "KUBECTL_VERSION" -e "KUBECTL_CHECKSUM_amd64" -e "KUBECTL_CHECKSUM_arm64" ./; then
     kubectl_fetch_data
     kubectl_save_arch_sources
   fi

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -66,7 +66,8 @@ kustomize_save_arch_sources() {
     grep "linux_${arch}" "${DATA_DIR}/kustomize-data.raw" | jq -n --raw-input --slurp '{ "releases": [
             inputs | split("\n")[]
             | select(test("^\\w+\\s+kustomize_"))
-            | match("(?<digest>\\w+)\\s+kustomize_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")
+            | (match("(?<digest>\\w+)\\s+kustomize_(?<version>v[\\d.]+)_(?<os>\\w+)_(?<arch>\\w+)\\..+")?)
+            | select(. != null)
             | { version: ("\(.captures[1].string)"), digest: .captures[0].string }
           ]}' >"${DATA_DIR}/kustomize-${arch}.json"
   done


### PR DESCRIPTION
Improve` kubectl` update safety by coupling version updates to locally generated checksum data and hardening datasource JSON generation. This prevents version-only `kubectl` bumps when checksum lookup cannot be resolved and avoids schema-invalid custom datasource payloads. The change also clarifies manager intent so canonical version sources and arch-specific checksum managers are explicit.

- Use `kubectl-amd64` as the canonical `custom.local` source for `Dockerfile/deps` and shell `KUBECTL_VERSION` extraction, while keeping separate arm64 checksum handling.

Followup to #747 