### PR TITLE
Fix kubectl datasource and k8s grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ their `renovate.json` as per below:
   "packageRules": [
     {
       "matchBaseBranches": ["releases/v0.7.x"],
-      "extends": ["github>rancher/renovate-config//rancher-2.11#release"]
+      "extends": ["github>rancher/renovate-config//rancher-2.14#release"]
     },
     {
       "matchBaseBranches": ["releases/v0.6.x"],
-      "extends": ["github>rancher/renovate-config//rancher-2.10#release"]
+      "extends": ["github>rancher/renovate-config//rancher-2.13#release"]
     }
   ]
 }

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -13,12 +13,19 @@ kustomize_fetch_data() {
 }
 
 kubectl_fetch_data() {
-  versions=$(curl --retry 3 --retry-connrefused -L https://api.github.com/repos/kubernetes/kubernetes/releases?per-page=100 | jq -r '.[].tag_name' | grep -v alpha | grep -v rc | grep -v beta)
+  versions=$(curl --retry 3 --retry-connrefused -L https://api.github.com/repos/kubernetes/kubernetes/releases?per-page=100 |
+    jq -r 'map(select(.tag_name | test("alpha|rc|beta") | not))[] | .tag_name')
 
   echo "${versions}" | while IFS= read -r version; do
     for arch in "${ARCHS[@]}"; do
-      curl --retry 3 --retry-connrefused -L "https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl.sha256" >>"${DATA_DIR}/kubectl-data.raw"
-      echo "  kubectl_${version}_linux_${arch}.tar.gz" >>"${DATA_DIR}/kubectl-data.raw"
+      if ! checksum=$(curl --retry 3 --retry-connrefused --fail -L "https://dl.k8s.io/release/${version}/bin/linux/${arch}/kubectl.sha256"); then
+        continue
+      fi
+      checksum="$(echo "${checksum}" | tr -d '\r\n')"
+      if [[ ! "${checksum}" =~ ^[0-9a-f]{64}$ ]]; then
+        continue
+      fi
+      echo "${checksum}  kubectl_${version}_linux_${arch}.tar.gz" >>"${DATA_DIR}/kubectl-data.raw"
     done
   done
 }

--- a/hack/generate-data-sources.sh
+++ b/hack/generate-data-sources.sh
@@ -13,7 +13,7 @@ kustomize_fetch_data() {
 }
 
 kubectl_fetch_data() {
-  versions=$(curl --retry 3 --retry-connrefused -L https://api.github.com/repos/kubernetes/kubernetes/releases?per-page=100 |
+  versions=$(curl --retry 3 --retry-connrefused -L https://api.github.com/repos/kubernetes/kubernetes/releases?per_page=100 |
     jq -r 'map(select(.tag_name | test("alpha|rc|beta") | not))[] | .tag_name')
 
   echo "${versions}" | while IFS= read -r version; do
@@ -22,7 +22,7 @@ kubectl_fetch_data() {
         continue
       fi
       checksum="$(echo "${checksum}" | tr -d '\r\n')"
-      if [[ ! "${checksum}" =~ ^[0-9a-f]{64}$ ]]; then
+      if [[ ! "${checksum}" =~ ^[[:xdigit:]]{64}$ ]]; then
         continue
       fi
       echo "${checksum}  kubectl_${version}_linux_${arch}.tar.gz" >>"${DATA_DIR}/kubectl-data.raw"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -56,7 +56,7 @@
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -67,7 +67,7 @@
       "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -87,7 +87,7 @@
       "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -56,7 +56,7 @@
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -67,7 +67,7 @@
       "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -87,7 +87,7 @@
       "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -56,7 +56,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -67,7 +67,7 @@
       "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -87,7 +87,7 @@
       "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -56,7 +56,7 @@
       "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -67,7 +67,7 @@
       "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -87,7 +87,7 @@
       "allowedVersions": "<0.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -40,7 +40,7 @@
       ],
       "allowedVersions": "<1.37.0",
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -61,7 +61,7 @@
       ],
       "allowedVersions": "<0.37.0",
       "groupName": "Kubernetes dependencies",
-      "minimumGroupSize": 5,
+      "minimumGroupSize": 15,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },


### PR DESCRIPTION
Write kubectl raw data as digest and filename on one line. Validate checksum format and skip invalid checksum fetches. Raise Kubernetes minimum group size to 15 in active presets. This avoids tiny grouped PRs when not all updated libraries are released yet.