### PR TITLE
feat: pin non fixed sha actions

### DIFF
--- a/default.json
+++ b/default.json
@@ -562,6 +562,13 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["rancher/renovate-config", "rancher/renovate-config/**"],
       "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Isolate and create PRs to pin GitHub Actions digests immediately with 0 days delay",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": "0 days",
+      "groupName": "Pin GitHub Actions"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -371,6 +371,15 @@
   ],
   "packageRules": [
     {
+      "description": "Create a grouped PR to pin GitHub Actions digests",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "matchDatasources": ["github-tags"],
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": "5 days",
+      "groupName": "Pin GitHub Actions"
+    },
+    {
       "description": "Restrict helm/chart-testing-action below 2.8.0",
       "matchPackageNames": [
         "helm/chart-testing-action"
@@ -562,15 +571,6 @@
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["rancher/renovate-config", "rancher/renovate-config/**"],
       "minimumReleaseAge": "2 days"
-    },
-    {
-      "description": "Create a grouped PR to pin GitHub Actions digests",
-      "matchManagers": ["github-actions"],
-      "matchDepTypes": ["action"],
-      "matchDatasources": ["github-tags"],
-      "matchUpdateTypes": ["pinDigest"],
-      "minimumReleaseAge": "5 days",
-      "groupName": "Pin GitHub Actions"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -566,6 +566,8 @@
     {
       "description": "Create a grouped PR to pin GitHub Actions digests",
       "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "matchDatasources": ["github-tags"],
       "matchUpdateTypes": ["pinDigest"],
       "minimumReleaseAge": "0 days",
       "groupName": "Pin GitHub Actions"

--- a/default.json
+++ b/default.json
@@ -569,7 +569,7 @@
       "matchDepTypes": ["action"],
       "matchDatasources": ["github-tags"],
       "matchUpdateTypes": ["pinDigest"],
-      "minimumReleaseAge": "0 days",
+      "minimumReleaseAge": "5 days",
       "groupName": "Pin GitHub Actions"
     }
   ]

--- a/default.json
+++ b/default.json
@@ -372,12 +372,23 @@
   "packageRules": [
     {
       "description": "Create a grouped PR to pin GitHub Actions digests",
+      "groupName": "Pin GitHub Actions",
       "matchManagers": ["github-actions"],
       "matchDepTypes": ["action"],
       "matchDatasources": ["github-tags"],
       "matchUpdateTypes": ["pinDigest"],
-      "minimumReleaseAge": "5 days",
-      "groupName": "Pin GitHub Actions"
+      "minimumReleaseAge": "5 days"
+    },
+    {
+      "description": "Update renovate-vault workflow references quickly after release",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["rancher/renovate-config", "rancher/renovate-config/**"],
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Exempt slsactl from minimumReleaseAge to allow immediate pickup",
+      "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "Restrict helm/chart-testing-action below 2.8.0",
@@ -461,20 +472,6 @@
       "minimumReleaseAge": "3 days"
     },
     {
-      "groupName": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchDatasources": [
-        "github-tags"
-      ],
-      "matchDepTypes": [
-        "action"
-      ],
-      "pinDigests": true,
-      "minimumReleaseAge": "28 days"
-    },
-    {
       "matchPackageNames": [
         "registry.suse.com/**",
         "registry.opensuse.org/**"
@@ -531,11 +528,6 @@
       ]
     },
     {
-      "description": "Exempt slsactl from minimumReleaseAge to allow immediate pickup",
-      "matchPackageNames": ["rancherlabs/slsactl", "rancherlabs/slsactl/**"],
-      "minimumReleaseAge": "0 days"
-    },
-    {
       "description": "Group and restrict rancherlabs/slsactl (GitHub tag and version parameter)",
       "matchPackageNames": ["rancherlabs/slsactl"],
       "groupName": "slsactl",
@@ -565,12 +557,6 @@
       "matchPackageNames": ["rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["digest"],
       "enabled": false
-    },
-    {
-      "description": "Update renovate-vault workflow references quickly after release",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["rancher/renovate-config", "rancher/renovate-config/**"],
-      "minimumReleaseAge": "2 days"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -564,7 +564,7 @@
       "minimumReleaseAge": "2 days"
     },
     {
-      "description": "Isolate and create PRs to pin GitHub Actions digests immediately with 0 days delay",
+      "description": "Create a grouped PR to pin GitHub Actions digests",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["pinDigest"],
       "minimumReleaseAge": "0 days",

--- a/default.json
+++ b/default.json
@@ -375,8 +375,9 @@
       "groupName": "Pin GitHub Actions",
       "matchManagers": ["github-actions"],
       "matchDepTypes": ["action"],
-      "matchDatasources": ["github-tags"],
+      "matchDatasources": ["github-tags", "github-releases"],
       "matchUpdateTypes": ["pinDigest"],
+      "pinDigests": true,
       "minimumReleaseAge": "5 days"
     },
     {


### PR DESCRIPTION
Adding this config, renovate, will pin automatically all the GH Actions which are not being pinned.
The pin will be to the exact same version that it's using at current moment, it won't update the version of the action.