### PR TITLE
Fix digestVersion regex capture

### DIFF
--- a/default.json
+++ b/default.json
@@ -338,7 +338,7 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)?( extractVersion=(?<extractVersion>.*?))?\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>[^\"\\s]*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ]
     },
     {
@@ -364,7 +364,7 @@
       ],
       "matchStrings": [
         "# renovate-local: (?<depName>.*)\\s+.+_(version|VERSION).*[:=](\\s|\"|)(?<currentValue>[^\"\\s]*)(\"|)",
-        "# renovate-local: (?<depName>.*)=(?<currentValue>.*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
+        "# renovate-local: (?<depName>.*)=(?<currentValue>[^\"\\s]*)\\s+.+_(sha256|arm64|amd64|arm|s390x|x86_64|SUM|CHECKSUM).*[:=](\\s|\"|)(?<currentDigest>[^\"\\s]*)(\"|)"
       ],
       "datasourceTemplate": "custom.local"
     }


### PR DESCRIPTION
Use non-greedy value captures for `digestVersion` regex managers to keep checksum updates aligned with the intended version token.

Should prevent that checksums were not updated like these: https://github.com/rancher/rancher/pull/55850