### PR TITLE
Gate Go Mod PRs On Green Checks

### DIFF
--- a/rancher-main.json
+++ b/rancher-main.json
@@ -3,6 +3,13 @@
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {
+      "description": "Only open gomod PRs after branch checks pass",
+      "matchManagers": [
+        "gomod"
+      ],
+      "prCreation": "status-success"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<16.1",
       "matchPackageNames": [


### PR DESCRIPTION
Set `prCreation` to `status-success` for `gomod` updates so Renovate opens PRs only after branch checks have succeeded.

Should prevent prs like https://github.com/rancher/rancher/pull/55927