### PR TITLE
Enable security bumps for release branches

### DIFF
--- a/default.json
+++ b/default.json
@@ -453,6 +453,12 @@
       "minimumGroupSize": 1
     },
     {
+      "description": "Prioritize vulnerability fix updates across all branches",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "prPriority": 100,
+      "prCreation": "immediate"
+    },
+    {
       "description": "Update renovate-vault workflow references quickly after release",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["rancher/renovate-config", "rancher/renovate-config/**"],

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -34,6 +34,12 @@
       "enabled": true
     },
     {
+      "description": "Block vulnerability updates above patch level",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -18,17 +18,7 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
-      "matchPackageNames": [
-        "!golang",
-        "!go",
-        "!registry.suse.com/bci/golang",
-        "!registry.opensuse.org/opensuse/bci/golang",
-        "!rancher/kubectl",
-        "!kubernetes/kubernetes",
-        "!k8s.io/kubernetes",
-        "!k8s.io/**"
-      ],
+      "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -14,6 +14,7 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
       "enabled": false
     },
     {

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -34,6 +34,12 @@
       "enabled": true
     },
     {
+      "description": "Block vulnerability updates above patch level",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -18,17 +18,7 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
-      "matchPackageNames": [
-        "!golang",
-        "!go",
-        "!registry.suse.com/bci/golang",
-        "!registry.opensuse.org/opensuse/bci/golang",
-        "!rancher/kubectl",
-        "!kubernetes/kubernetes",
-        "!k8s.io/kubernetes",
-        "!k8s.io/**"
-      ],
+      "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -14,6 +14,7 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
       "enabled": false
     },
     {

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -34,6 +34,12 @@
       "enabled": true
     },
     {
+      "description": "Block vulnerability updates above patch level",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -18,17 +18,7 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
-      "matchPackageNames": [
-        "!golang",
-        "!go",
-        "!registry.suse.com/bci/golang",
-        "!registry.opensuse.org/opensuse/bci/golang",
-        "!rancher/kubectl",
-        "!kubernetes/kubernetes",
-        "!k8s.io/kubernetes",
-        "!k8s.io/**"
-      ],
+      "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -14,6 +14,7 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
       "enabled": false
     },
     {

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -34,6 +34,12 @@
       "enabled": true
     },
     {
+      "description": "Block vulnerability updates above patch level",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "description": "Enable patch updates for Go packages",
       "matchPackageNames": [
         "golang",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -18,17 +18,7 @@
       "enabled": false
     },
     {
-      "description": "Enable updates for packages with known vulnerabilities (except Go/K8s/test deps)",
-      "matchPackageNames": [
-        "!golang",
-        "!go",
-        "!registry.suse.com/bci/golang",
-        "!registry.opensuse.org/opensuse/bci/golang",
-        "!rancher/kubectl",
-        "!kubernetes/kubernetes",
-        "!k8s.io/kubernetes",
-        "!k8s.io/**"
-      ],
+      "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
       "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
       "enabled": true

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -14,6 +14,7 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
       "enabled": false
     },
     {

--- a/rancher-main.json
+++ b/rancher-main.json
@@ -3,13 +3,6 @@
   "extends": ["github>rancher/renovate-config#release"],
   "packageRules": [
     {
-      "description": "Only open gomod PRs after branch checks pass",
-      "matchManagers": [
-        "gomod"
-      ],
-      "prCreation": "status-success"
-    },
-    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<16.1",
       "matchPackageNames": [


### PR DESCRIPTION
## Summary

This PR makes security-fix update handling reliable for supported Rancher release branches, prioritizes those updates, and narrows release security updates to patch level.

## What changed

- Switched release-branch security matching from branch-name heuristics to Renovate vulnerability metadata.
- Updated shared prioritization so vulnerability-fix PRs are created immediately and sorted ahead of regular dependency updates.
- Added release rules to block vulnerability updates above patch level (`major` and `minor`).
- Removed Go/Kubernetes exclusions from the vulnerability-enable rule so patch-level security updates for those dependencies are allowed.
- Reverted the Go Mod gating change because Renovate was not consistently waiting long enough for CI-green state, which caused skips (for example toolchain bumps).

## Why this update

- Branch-name-based detection was brittle and could still allow security candidates to be filtered before PR creation on release branches.
- Matching on vulnerability metadata ties behavior to the actual security-fix signal.
- Release streams should accept security patch updates but avoid broader-risk security jumps (`minor`/`major`).

## Goald

- Security-fix updates for supported release streams are no longer coupled to branch naming.
- Security-fix PRs are surfaced ahead of normal dependency updates.
- Patch-level security updates are allowed across dependency classes, including Go/Kubernetes.
- Vulnerability `minor`/`major` updates remain blocked for release presets.