### PR TITLE
Recognize OSV release updates

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -14,18 +14,18 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
-      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
     },
     {
       "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "enabled": true
     },
     {
       "description": "Block vulnerability updates above patch level",
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -14,18 +14,18 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
-      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
     },
     {
       "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "enabled": true
     },
     {
       "description": "Block vulnerability updates above patch level",
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -14,18 +14,18 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
-      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
     },
     {
       "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "enabled": true
     },
     {
       "description": "Block vulnerability updates above patch level",
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -14,18 +14,18 @@
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
-      "matchJsonata": ["$not($exists(vulnerabilityFixVersion))"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
     },
     {
       "description": "Enable updates for packages with known vulnerabilities (except test deps)",
       "matchDepTypes": ["!devDependencies", "!dev-dependencies", "!test"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "enabled": true
     },
     {
       "description": "Block vulnerability updates above patch level",
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     },


### PR DESCRIPTION
Treat OSV vulnerability alerts as security updates in release presets.

This together with the new tagged (`v1.0.4`) rancher/renovate-config should provide security bumps for release branches.