### PR TITLE
Allow independent OSV security patches

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -99,6 +99,18 @@
       "groupName": "slsactl",
       "allowedVersions": "<=v0.1.22",
       "minimumGroupSize": 2
+    },
+    {
+      "description": "Create patch vulnerability updates independently",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "minimumGroupSize": 1,
+      "branchConcurrentLimit": 0,
+      "prConcurrentLimit": 0,
+      "prHourlyLimit": 0,
+      "prPriority": 100,
+      "prCreation": "immediate"
     }
   ]
 }

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -99,6 +99,18 @@
       "groupName": "slsactl",
       "allowedVersions": "<=v0.1.22",
       "minimumGroupSize": 2
+    },
+    {
+      "description": "Create patch vulnerability updates independently",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "minimumGroupSize": 1,
+      "branchConcurrentLimit": 0,
+      "prConcurrentLimit": 0,
+      "prHourlyLimit": 0,
+      "prPriority": 100,
+      "prCreation": "immediate"
     }
   ]
 }

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -99,6 +99,18 @@
       "groupName": "slsactl",
       "allowedVersions": "<=v0.1.22",
       "minimumGroupSize": 2
+    },
+    {
+      "description": "Create patch vulnerability updates independently",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "minimumGroupSize": 1,
+      "branchConcurrentLimit": 0,
+      "prConcurrentLimit": 0,
+      "prHourlyLimit": 0,
+      "prPriority": 100,
+      "prCreation": "immediate"
     }
   ]
 }

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -99,6 +99,18 @@
       "groupName": "slsactl",
       "allowedVersions": "<=v0.1.22",
       "minimumGroupSize": 2
+    },
+    {
+      "description": "Create patch vulnerability updates independently",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": true,
+      "minimumGroupSize": 1,
+      "branchConcurrentLimit": 0,
+      "prConcurrentLimit": 0,
+      "prHourlyLimit": 0,
+      "prPriority": 100,
+      "prCreation": "immediate"
     }
   ]
 }


### PR DESCRIPTION
Match OSV vulnerability alerts so their patch fixes bypass release preset grouping thresholds alongside GitHub vulnerability alerts.

The idea is to not rate limit security bumps, to prevent some release branches or similar not getting all required security updates in time.