### PR TITLE
Enable minor and patch level security updates on release branches

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -24,9 +24,9 @@
       "enabled": true
     },
     {
-      "description": "Block vulnerability updates above patch level",
+      "description": "Block vulnerability updates above minor level",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -111,6 +111,19 @@
       "prHourlyLimit": 0,
       "prPriority": 100,
       "prCreation": "immediate"
+    },
+    {
+      "description": "Keep minor Helm and Kubernetes updates out of release branches",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": [
+        "helm/**",
+        "helm.sh/helm/**",
+        "helm-amd64",
+        "helm-arm64",
+        "rancher/helm"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
     }
   ]
 }

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -24,9 +24,9 @@
       "enabled": true
     },
     {
-      "description": "Block vulnerability updates above patch level",
+      "description": "Block vulnerability updates above minor level",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -111,6 +111,19 @@
       "prHourlyLimit": 0,
       "prPriority": 100,
       "prCreation": "immediate"
+    },
+    {
+      "description": "Keep minor Helm and Kubernetes updates out of release branches",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": [
+        "helm/**",
+        "helm.sh/helm/**",
+        "helm-amd64",
+        "helm-arm64",
+        "rancher/helm"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
     }
   ]
 }

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -24,9 +24,9 @@
       "enabled": true
     },
     {
-      "description": "Block vulnerability updates above patch level",
+      "description": "Block vulnerability updates above minor level",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -111,6 +111,19 @@
       "prHourlyLimit": 0,
       "prPriority": 100,
       "prCreation": "immediate"
+    },
+    {
+      "description": "Keep minor Helm and Kubernetes updates out of release branches",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": [
+        "helm/**",
+        "helm.sh/helm/**",
+        "helm-amd64",
+        "helm-arm64",
+        "rancher/helm"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
     }
   ]
 }

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -24,9 +24,9 @@
       "enabled": true
     },
     {
-      "description": "Block vulnerability updates above patch level",
+      "description": "Block vulnerability updates above minor level",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -111,6 +111,19 @@
       "prHourlyLimit": 0,
       "prPriority": 100,
       "prCreation": "immediate"
+    },
+    {
+      "description": "Keep minor Helm and Kubernetes updates out of release branches",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": [
+        "helm/**",
+        "helm.sh/helm/**",
+        "helm-amd64",
+        "helm-arm64",
+        "rancher/helm"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
     }
   ]
 }

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -24,9 +24,9 @@
       "enabled": true
     },
     {
-      "description": "Block vulnerability updates above patch level",
+      "description": "Block vulnerability updates above minor level",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
@@ -111,6 +111,19 @@
       "prHourlyLimit": 0,
       "prPriority": 100,
       "prCreation": "immediate"
+    },
+    {
+      "description": "Keep minor Helm and Kubernetes updates out of release branches",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": [
+        "helm/**",
+        "helm.sh/helm/**",
+        "helm-amd64",
+        "helm-arm64",
+        "rancher/helm"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
while disabling Helm minor bumps to prevent incompatibilities, because minor helm bumps require new Kubernetes versions.

Kubernetes and Go minor bumps should be already restricted by the `allowedVersions`.