### PR TITLE
Add Rancher release package rules to default Renovate config

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -59,7 +59,7 @@ jobs:
           git checkout -b "${BRANCH}"
           mkdir -p .github/workflows
           TEMP_CONFIG=$(mktemp)
-          jq --arg default_branch "${DEFAULT_BRANCH}" '.baseBranchPatterns = [$default_branch]' ../main/files/renovate.json > "${TEMP_CONFIG}"
+          jq --arg default_branch "${DEFAULT_BRANCH}" '.baseBranchPatterns |= map(if . == "main" then $default_branch else . end)' ../main/files/renovate.json > "${TEMP_CONFIG}"
 
           if [ ! -f .github/renovate.json ]; then
             mv "${TEMP_CONFIG}" .github/renovate.json

--- a/files/renovate.json
+++ b/files/renovate.json
@@ -1,6 +1,55 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
-  "baseBranchPatterns": ["main"],
-  "prHourlyLimit": 2
+  "baseBranchPatterns": [
+    "main",
+    "release/v2.15",
+    "release/v2.14",
+    "release/v2.13",
+    "release/v2.12",
+    "release/v2.11"
+  ],
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "matchBaseBranches": [
+        "release/v2.15"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.15#release"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release/v2.14"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.14#release"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release/v2.13"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.13#release"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release/v2.12"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.12#release"
+      ]
+    },
+    {
+      "matchBaseBranches": [
+        "release/v2.11"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-2.11#release"
+      ]
+    }
+  ]
 }

--- a/files/renovate.json
+++ b/files/renovate.json
@@ -12,6 +12,7 @@
   "prHourlyLimit": 2,
   "packageRules": [
     {
+      "description": "Apply Rancher 2.15 update constraints to branch release/v2.15. Adapt baseBranchPatterns and matchBaseBranches if this repository uses different release branch names.",
       "matchBaseBranches": [
         "release/v2.15"
       ],
@@ -20,6 +21,7 @@
       ]
     },
     {
+      "description": "Apply Rancher 2.14 update constraints to branch release/v2.14. Adapt baseBranchPatterns and matchBaseBranches if this repository uses different release branch names.",
       "matchBaseBranches": [
         "release/v2.14"
       ],
@@ -28,6 +30,7 @@
       ]
     },
     {
+      "description": "Apply Rancher 2.13 update constraints to branch release/v2.13. Adapt baseBranchPatterns and matchBaseBranches if this repository uses different release branch names.",
       "matchBaseBranches": [
         "release/v2.13"
       ],
@@ -36,6 +39,7 @@
       ]
     },
     {
+      "description": "Apply Rancher 2.12 update constraints to branch release/v2.12. Adapt baseBranchPatterns and matchBaseBranches if this repository uses different release branch names.",
       "matchBaseBranches": [
         "release/v2.12"
       ],
@@ -44,6 +48,7 @@
       ]
     },
     {
+      "description": "Apply Rancher 2.11 update constraints to branch release/v2.11. Adapt baseBranchPatterns and matchBaseBranches if this repository uses different release branch names.",
       "matchBaseBranches": [
         "release/v2.11"
       ],


### PR DESCRIPTION
Add release-specific `packageRules` to the deployment default renovate config which is used for deployment (based on the Rancher [renovate.json](https://github.com/rancher/rancher/blob/main/.github/renovate.json)).
This allows newly deployed Renovate configurations to target dependency updates according to the corresponding Rancher release.

If the target repos have branch names different then the ones of Rancher they need to be adapted manually.
But even if the config is not adapted it should not break Renovate, it would just not provide targeted restricted updates for these release branches.

The Renovate deployment script was adapted to replace the default branch without replacing the other `basePatterns`.