### PR TITLE
Enable minor and patch level update automerge rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -456,6 +456,17 @@
   ],
   "packageRules": [
     {
+      "description": "Automerge patch and minor updates",
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge security updates",
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
+    },
+    {
       "description": "Create a grouped PR to pin GitHub Actions digests",
       "groupName": "Pin GitHub Actions",
       "matchManagers": ["github-actions"],

--- a/default.json
+++ b/default.json
@@ -457,9 +457,10 @@
   "packageRules": [
     {
       "description": "Automerge patch and minor updates",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
-    },
+    }
     {
       "description": "Automerge security updates",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],


### PR DESCRIPTION
both for security and regular bumps.

This has only an affected if automerge is allowed in the repo.a Also if the repo requires and approval, like most repos, then a separate CI job is needed to approve the pr automatically.

The repos using Renovate automerge should make sure, that the CI status is required for prs to be merged, so it is assured that CI was successful before the pr could be automatically merged.

I do not see any risk enabling automerge, because most repos do not have automerge enabled in their Github repo settings and on top I do not know any relevant project not requiring approvals.

So with this change project owners using Renovate can decide on their own to use Renovate automerge when they want by enabling automerge and also adding a CI action for approving those Renovate prs.