### PR TITLE
Add missing comma

### DIFF
--- a/default.json
+++ b/default.json
@@ -460,7 +460,7 @@
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
-    }
+    },
     {
       "description": "Automerge security updates",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],


### PR DESCRIPTION
which was accidentally introduced by a [Copilot suggestion](https://github.com/rancher/renovate-config/pull/794/changes/456f4e8bf2907fda2613dd83bf3a65f119bede0b). `make validate` does not complain about the issue and it seems Renovate still worked fine.