### PR TITLE
Omit empty package rules

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -89,7 +89,8 @@ jobs:
               .baseBranchPatterns |= map(select(startswith("release/") | not)) |
               .packageRules |= map(select((.matchBaseBranches // []) | all(startswith("release/") | not)))
             end |
-            .baseBranchPatterns |= map(if . == "main" then $default_branch else . end)' \
+            .baseBranchPatterns |= map(if . == "main" then $default_branch else . end) |
+            if (.packageRules | length) == 0 then del(.packageRules) else . end' \
             ../main/files/renovate.json > "${TEMP_CONFIG}"
 
           if [ ! -f .github/renovate.json ]; then


### PR DESCRIPTION
Avoid writing empty packageRules when deployment excludes release branches.