### PR TITLE
Disable routine Rancher module bumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -546,7 +546,11 @@
     {
       "description": "Let Rancher teams manage internal product updates",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["github.com/rancher/**"],
+      "matchPackageNames": [
+        "github.com/rancher/**",
+        "!github.com/rancher/wrangler/v3",
+        "!github.com/rancher/lasso"
+      ],
       "matchJsonata": [
         "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
       ],

--- a/default.json
+++ b/default.json
@@ -544,6 +544,15 @@
       "minimumReleaseAge": "3 days"
     },
     {
+      "description": "Let Rancher teams manage internal product updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/rancher/**"],
+      "matchJsonata": [
+        "$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Group kubectl version and checksum dependencies with kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubernetes/kubernetes", "k8s.io/kubernetes", "kubectl-amd64", "kubectl-arm64"],


### PR DESCRIPTION
## Summary

Disable routine Renovate bumps for Rancher-owned Go modules under `github.com/rancher/**`.

Wrangler and Lasso remain exempt from suppression so their updates continue to be grouped together through the existing `wrangler-lasso` rule.

## Rationale

Rancher product teams manage updates for internal products such as `rancher/machine` and `rancher/apiserver`. Renovate should avoid creating routine update PRs for those modules.

Wrangler and Lasso remain exempt because they are required to be bumped in many rancher projects.

Vulnerability-related updates remain enabled.

Should prevent prs like:
https://github.com/rancher/rancher/pull/56504