### PR TITLE
Group Renovate version updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -531,7 +531,8 @@
         "renovate/renovate"
       ],
       "extractVersion": "(?<version>.*)-full$",
-      "groupName": "renovate-bumps"
+      "groupName": "renovate-bumps",
+      "separateMajorMinor": false
     },
     {
       "description": "Allow Wrangler and lasso updates to be created after 3 days because they are internal products",


### PR DESCRIPTION
Should prevent split Renovate updates like these and also the version getting out of sync:
https://github.com/rancher/renovate-config/pull/807
https://github.com/rancher/renovate-config/pull/806