### PR TITLE
Use Renovate default branch pattern

### DIFF
--- a/.github/workflows/renovate-deploy.yml
+++ b/.github/workflows/renovate-deploy.yml
@@ -83,13 +83,11 @@ jobs:
           mkdir -p .github/workflows
           TEMP_CONFIG=$(mktemp)
           jq \
-            --arg default_branch "${DEFAULT_BRANCH}" \
             --argjson include_release_branches "${INCLUDE_RELEASE_BRANCHES}" \
             'if $include_release_branches then . else
               .baseBranchPatterns |= map(select(startswith("release/") | not)) |
               .packageRules |= map(select((.matchBaseBranches // []) | all(startswith("release/") | not)))
             end |
-            .baseBranchPatterns |= map(if . == "main" then $default_branch else . end) |
             if (.packageRules | length) == 0 then del(.packageRules) else . end' \
             ../main/files/renovate.json > "${TEMP_CONFIG}"
 

--- a/files/renovate.json
+++ b/files/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>rancher/renovate-config#release"],
   "baseBranchPatterns": [
-    "main",
+    "$default",
     "release/v2.15",
     "release/v2.14",
     "release/v2.13",


### PR DESCRIPTION
Set the deployed configuration to use Renovate's  base branch pattern directly. 