### PR TITLE
Disable global Renovate automerging

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,7 +15,6 @@
     "dependencies"
   ],
   "automergeStrategy": "merge-commit",
-  "prConcurrentLimit": 0,
   "minimumReleaseAge": "7 days",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "postUpdateOptions": [

--- a/default.json
+++ b/default.json
@@ -455,16 +455,16 @@
   ],
   "packageRules": [
     {
-      "description": "Automerge patch and minor updates",
+      "description": "Disable automerge for patch and minor updates",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "automerge": false
     },
     {
-      "description": "Automerge security updates",
+      "description": "Disable automerge for security updates",
       "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
       "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "automerge": false
     },
     {
       "description": "Create a grouped PR to pin GitHub Actions digests",


### PR DESCRIPTION
Remove unlimited PR concurrency and disable shared automerge rules.
Automerging can be enabled selectively in repository configurations, to prevent issues in repos which do not have branch protection rules.

Follow up prs in:
[Fleet](https://github.com/rancher/fleet/pull/5557)
[Rancher](https://github.com/rancher/rancher/pull/56611)