### PR TITLE
Disable Go module directive updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -607,6 +607,15 @@
       "groupName": "Go toolchain"
     },
     {
+      "description": "Disable patch Go module directive updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "enabled": false
+    },
+    {
       "description": "Allow Go runtime updates after 2 days to get security releases faster",
       "matchDatasources": [
         "golang-version"

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -13,6 +13,7 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
+      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
@@ -31,6 +32,7 @@
     },
     {
       "description": "Enable patch updates for Go packages",
+      "matchDepTypes": ["!golang"],
       "matchPackageNames": [
         "golang",
         "go",
@@ -42,9 +44,17 @@
     },
     {
       "description": "Enable patch updates for golang-version datasource",
+      "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
       "enabled": true
+    },
+    {
+      "description": "Apply Go version cap to module directives",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
     },
     {
       "description": "Enable patch updates for kubectl",

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -13,6 +13,7 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
+      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
@@ -31,6 +32,7 @@
     },
     {
       "description": "Enable patch updates for Go packages",
+      "matchDepTypes": ["!golang"],
       "matchPackageNames": [
         "golang",
         "go",
@@ -42,9 +44,17 @@
     },
     {
       "description": "Enable patch updates for golang-version datasource",
+      "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
       "enabled": true
+    },
+    {
+      "description": "Apply Go version cap to module directives",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
     },
     {
       "description": "Enable patch updates for kubectl",

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -13,6 +13,7 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
+      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
@@ -31,6 +32,7 @@
     },
     {
       "description": "Enable patch updates for Go packages",
+      "matchDepTypes": ["!golang"],
       "matchPackageNames": [
         "golang",
         "go",
@@ -42,9 +44,17 @@
     },
     {
       "description": "Enable patch updates for golang-version datasource",
+      "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
       "enabled": true
+    },
+    {
+      "description": "Apply Go version cap to module directives",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
     },
     {
       "description": "Enable patch updates for kubectl",

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -13,6 +13,7 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
+      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
@@ -31,6 +32,7 @@
     },
     {
       "description": "Enable patch updates for Go packages",
+      "matchDepTypes": ["!golang"],
       "matchPackageNames": [
         "golang",
         "go",
@@ -42,9 +44,17 @@
     },
     {
       "description": "Enable patch updates for golang-version datasource",
+      "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
       "enabled": true
+    },
+    {
+      "description": "Apply Go version cap to module directives",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
     },
     {
       "description": "Enable patch updates for kubectl",

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -13,6 +13,7 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
+      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
@@ -31,6 +32,7 @@
     },
     {
       "description": "Enable patch updates for Go packages",
+      "matchDepTypes": ["!golang"],
       "matchPackageNames": [
         "golang",
         "go",
@@ -42,9 +44,17 @@
     },
     {
       "description": "Enable patch updates for golang-version datasource",
+      "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.27",
       "enabled": true
+    },
+    {
+      "description": "Apply Go version cap to module directives",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.27"
     },
     {
       "description": "Enable patch updates for kubectl",


### PR DESCRIPTION
Keep Renovate focused on Go toolchain changes.
Security bumps and future minor bumps are not blocked, only patch level go directive bumps should be blocked.

Should prevent prs like:
https://github.com/rancher/fleet/pull/5558
https://github.com/rancher/rancher/pull/56630