### PR TITLE
Group AWS and opentelemetry dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -708,6 +708,12 @@
       "groupName": "AWS dependencies"
     },
     {
+      "description": "Group go.opentelemetry.io/ packages together",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/**"],
+      "groupName": "OpenTelemetry dependencies"
+    },
+    {
       "description": "Group golang.org/x/ packages together as they release in sync and go get forces co-updates",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["golang.org/x/**"],

--- a/default.json
+++ b/default.json
@@ -702,6 +702,12 @@
       "groupName": "ginkgo and gomega"
     },
     {
+      "description": "Group github.com/aws/ packages together",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/aws/**"],
+      "groupName": "AWS dependencies"
+    },
+    {
       "description": "Group golang.org/x/ packages together as they release in sync and go get forces co-updates",
       "matchManagers": ["gomod"],
       "matchPackageNames": ["golang.org/x/**"],


### PR DESCRIPTION
Should group the [different aws prs](https://github.com/rancher/rancher/pulls?q=is%3Apr+aws+author%3Aapp%2Frenovate-rancher) to one.
And do the same for opentelemetry packages.