### PR TITLE
Fix regression in release branch regex based bumps

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -13,7 +13,6 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
-      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -13,7 +13,6 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
-      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -13,7 +13,6 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
-      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -13,7 +13,6 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
-      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -13,7 +13,6 @@
     },
     {
       "matchPackageNames": ["!rancherlabs/slsactl", "!rancherlabs/slsactl/**"],
-      "matchDepTypes": ["!golang"],
       "matchUpdateTypes": ["major","minor","patch","pin","digest","pinDigest"],
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false


### PR DESCRIPTION
Prevent custom regex dependencies without a depType from bypassing release-branch update restrictions. Keep release branches limited to security, Go, and Kubernetes patch updates.

Should fix regression introduced in #815 while keeping the functionality.

Prevent regex releated release branch bumps like:
https://github.com/rancher/fleet/pull/5572
https://github.com/rancher/fleet/pull/5573