### PR TITLE
Keep Go toolchain and Docker image updates synchronized

### DIFF
--- a/default.json
+++ b/default.json
@@ -606,10 +606,11 @@
       "groupName": "Go toolchain"
     },
     {
-      "description": "Bump go directive on Go releases",
+      "description": "Bump go directive on minor Go releases",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "matchDatasources": ["golang-version"],
+      "matchJsonata": ["updateType = 'minor'"],
       "rangeStrategy": "bump",
       "groupName": "Go toolchain"
     },

--- a/default.json
+++ b/default.json
@@ -31,6 +31,19 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/(^|/)\.github/workflows/.*\.ya?ml$/"
+      ],
+      "description": "Track Go toolchain versions configured in GitHub Actions workflows",
+      "matchStrings": [
+        "GOTOOLCHAIN=go(?<currentValue>\\d+\\.\\d+\\.\\d+)\\+auto"
+      ],
+      "autoReplaceStringTemplate": "GOTOOLCHAIN=go{{{newValue}}}+auto",
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/\\.github/workflows/renovate.yml/",
         "/\\.github/workflows/renovate-vault.yml/"
       ],
@@ -624,6 +637,13 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
+      "groupName": "Go toolchain"
+    },
+    {
+      "description": "Group Go workflow toolchain updates with Go updates",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["golang-version"],
+      "matchPackageNames": ["go"],
       "groupName": "Go toolchain"
     },
     {

--- a/default.json
+++ b/default.json
@@ -606,6 +606,26 @@
       "groupName": "Go toolchain"
     },
     {
+      "description": "Bump go directive on Go releases",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump",
+      "groupName": "Go toolchain"
+    },
+    {
+      "description": "Group Go Docker image updates with toolchain updates",
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "golang",
+        "go",
+        "registry.suse.com/bci/golang",
+        "registry.opensuse.org/opensuse/bci/golang"
+      ],
+      "groupName": "Go toolchain"
+    },
+    {
       "description": "Disable patch Go module directive updates",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],

--- a/default.json
+++ b/default.json
@@ -31,7 +31,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|/)\.github/workflows/.*\.ya?ml$/"
+        "/(^|/)\\.github/workflows/.*\\.ya?ml$/"
       ],
       "description": "Track Go toolchain versions configured in GitHub Actions workflows",
       "matchStrings": [
@@ -652,7 +652,6 @@
       "matchDepTypes": ["golang"],
       "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["patch"],
-      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "enabled": false
     },
     {

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -123,6 +123,14 @@
       "prCreation": "immediate"
     },
     {
+      "description": "Disable patch Go module directive updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -123,6 +123,14 @@
       "prCreation": "immediate"
     },
     {
+      "description": "Disable patch Go module directive updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -123,6 +123,14 @@
       "prCreation": "immediate"
     },
     {
+      "description": "Disable patch Go module directive updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -123,6 +123,14 @@
       "prCreation": "immediate"
     },
     {
+      "description": "Disable patch Go module directive updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -123,6 +123,14 @@
       "prCreation": "immediate"
     },
     {
+      "description": "Disable patch Go module directive updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [


### PR DESCRIPTION
while preserving Go directive behavior.

Go module `go` directives now update only for minor Go releases. Patch and security updates update the Go toolchain and Dockerfile image reference without changing the directive. Dockerfile Go images and Go toolchain updates share one Renovate PR.

Should fix https://github.com/rancher/rancher/pull/56666