### PR TITLE
Add missing Go toolchain directives

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,6 +31,19 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/(^|/)go\\.mod$/"
+      ],
+      "description": "Add a Go toolchain directive when go.mod has none",
+      "matchStrings": [
+        "go (?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\\n\\n(?<nextDirective>replace|require) \\("
+      ],
+      "autoReplaceStringTemplate": "go {{{currentValue}}}\\ntoolchain go{{{newValue}}}\\n\\n{{{nextDirective}}} (",
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/(^|/)\\.github/workflows/.*\\.ya?ml$/"
       ],
       "description": "Track Go toolchain versions configured in GitHub Actions workflows",


### PR DESCRIPTION
Insert patch toolchain updates when `go.mod` lacks a toolchain directive.

For example this [pr](https://github.com/rancher/rancher/pull/56705)  does not update the [./go.mod](https://github.com/rancher/rancher/blob/fe5b361b8cfdb299faf194d184488891f9e5a4bc/go.mod#L3-L5).
This case should be handled with this change.