### PR TITLE
Enable release Go security updates and prioritize release bumps

### DIFF
--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -60,7 +60,6 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -69,7 +68,6 @@
       "description": "Enable patch updates for golang-version datasource",
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -85,7 +83,6 @@
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
-      "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -98,7 +95,6 @@
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -120,7 +116,6 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.33",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -130,6 +130,14 @@
       "enabled": false
     },
     {
+      "description": "Enable Go module vulnerability updates",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "enabled": true
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -39,6 +39,8 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -46,6 +48,8 @@
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -63,6 +67,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -74,6 +80,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -94,6 +102,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.11.json
+++ b/rancher-2.11.json
@@ -4,6 +4,28 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Apply Go package version cap to all updates",
+      "matchPackageNames": ["golang", "go", "registry.suse.com/bci/golang", "registry.opensuse.org/opensuse/bci/golang"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Go datasource version cap to all updates",
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Kubernetes version caps to all updates",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.33"
+    },
+    {
+      "description": "Apply k8s.io dependency version cap to all updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["!k8s.io/kubernetes", "!k8s.io/gengo", "!k8s.io/gengo/**", "!k8s.io/utils", "!k8s.io/utils/**", "!k8s.io/kube-openapi", "!k8s.io/kube-openapi/**", "k8s.io/**"],
+      "allowedVersions": "<0.33"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<15.8",
       "matchPackageNames": [

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -130,6 +130,14 @@
       "enabled": false
     },
     {
+      "description": "Enable Go module vulnerability updates",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "enabled": true
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -60,7 +60,6 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -69,7 +68,6 @@
       "description": "Enable patch updates for golang-version datasource",
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -85,7 +83,6 @@
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
-      "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -98,7 +95,6 @@
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -120,7 +116,6 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.34",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -39,6 +39,8 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -46,6 +48,8 @@
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -63,6 +67,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -74,6 +80,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -94,6 +102,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.12.json
+++ b/rancher-2.12.json
@@ -4,6 +4,28 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Apply Go package version cap to all updates",
+      "matchPackageNames": ["golang", "go", "registry.suse.com/bci/golang", "registry.opensuse.org/opensuse/bci/golang"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Go datasource version cap to all updates",
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Kubernetes version caps to all updates",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.33"
+    },
+    {
+      "description": "Apply k8s.io dependency version cap to all updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["!k8s.io/kubernetes", "!k8s.io/gengo", "!k8s.io/gengo/**", "!k8s.io/utils", "!k8s.io/utils/**", "!k8s.io/kube-openapi", "!k8s.io/kube-openapi/**", "k8s.io/**"],
+      "allowedVersions": "<0.33"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<15.8",
       "matchPackageNames": [

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -130,6 +130,14 @@
       "enabled": false
     },
     {
+      "description": "Enable Go module vulnerability updates",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "enabled": true
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -39,6 +39,8 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -46,6 +48,8 @@
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -63,6 +67,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -74,6 +80,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -94,6 +102,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -60,7 +60,6 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -69,7 +68,6 @@
       "description": "Enable patch updates for golang-version datasource",
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -85,7 +83,6 @@
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
-      "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -98,7 +95,6 @@
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -120,7 +116,6 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.35",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,

--- a/rancher-2.13.json
+++ b/rancher-2.13.json
@@ -4,6 +4,28 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Apply Go package version cap to all updates",
+      "matchPackageNames": ["golang", "go", "registry.suse.com/bci/golang", "registry.opensuse.org/opensuse/bci/golang"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Go datasource version cap to all updates",
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Kubernetes version caps to all updates",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.33"
+    },
+    {
+      "description": "Apply k8s.io dependency version cap to all updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["!k8s.io/kubernetes", "!k8s.io/gengo", "!k8s.io/gengo/**", "!k8s.io/utils", "!k8s.io/utils/**", "!k8s.io/kube-openapi", "!k8s.io/kube-openapi/**", "k8s.io/**"],
+      "allowedVersions": "<0.33"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<15.8",
       "matchPackageNames": [

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -130,6 +130,14 @@
       "enabled": false
     },
     {
+      "description": "Enable Go module vulnerability updates",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "enabled": true
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -39,6 +39,8 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -46,6 +48,8 @@
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.26",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -63,6 +67,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -74,6 +80,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -94,6 +102,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -60,7 +60,6 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -69,7 +68,6 @@
       "description": "Enable patch updates for golang-version datasource",
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.26",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -85,7 +83,6 @@
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
-      "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -98,7 +95,6 @@
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -120,7 +116,6 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.36",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,

--- a/rancher-2.14.json
+++ b/rancher-2.14.json
@@ -4,6 +4,28 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Apply Go package version cap to all updates",
+      "matchPackageNames": ["golang", "go", "registry.suse.com/bci/golang", "registry.opensuse.org/opensuse/bci/golang"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Go datasource version cap to all updates",
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.26"
+    },
+    {
+      "description": "Apply Kubernetes version caps to all updates",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.33"
+    },
+    {
+      "description": "Apply k8s.io dependency version cap to all updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["!k8s.io/kubernetes", "!k8s.io/gengo", "!k8s.io/gengo/**", "!k8s.io/utils", "!k8s.io/utils/**", "!k8s.io/kube-openapi", "!k8s.io/kube-openapi/**", "k8s.io/**"],
+      "allowedVersions": "<0.33"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<15.8",
       "matchPackageNames": [

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -4,6 +4,28 @@
   "vulnerabilityAlerts": { "enabled": true },
   "packageRules": [
     {
+      "description": "Apply Go package version cap to all updates",
+      "matchPackageNames": ["golang", "go", "registry.suse.com/bci/golang", "registry.opensuse.org/opensuse/bci/golang"],
+      "allowedVersions": "<1.27"
+    },
+    {
+      "description": "Apply Go datasource version cap to all updates",
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "<1.27"
+    },
+    {
+      "description": "Apply Kubernetes version caps to all updates",
+      "matchManagers": ["gomod", "custom.regex", "dockerfile"],
+      "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64", "kubernetes/kubernetes", "k8s.io/kubernetes"],
+      "allowedVersions": "<1.37"
+    },
+    {
+      "description": "Apply k8s.io dependency version cap to all updates",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["!k8s.io/kubernetes", "!k8s.io/gengo", "!k8s.io/gengo/**", "!k8s.io/utils", "!k8s.io/utils/**", "!k8s.io/kube-openapi", "!k8s.io/kube-openapi/**", "k8s.io/**"],
+      "allowedVersions": "<0.37"
+    },
+    {
       "description": "Restrict BCI images to maintained versions only",
       "allowedVersions": "<15.8",
       "matchPackageNames": [

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -130,6 +130,14 @@
       "enabled": false
     },
     {
+      "description": "Enable Go module vulnerability updates",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
+      "enabled": true
+    },
+    {
       "description": "Keep minor Helm and Kubernetes updates out of release branches",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": [

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -60,7 +60,6 @@
         "registry.suse.com/bci/golang",
         "registry.opensuse.org/opensuse/bci/golang"
       ],
-      "allowedVersions": "<1.27",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -69,7 +68,6 @@
       "description": "Enable patch updates for golang-version datasource",
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "<1.27",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "prPriority": 50,
       "enabled": true
@@ -85,7 +83,6 @@
       "description": "Enable patch updates for kubectl",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["rancher/kubectl", "kubectl-amd64", "kubectl-arm64"],
-      "allowedVersions": "<1.37",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -98,7 +95,6 @@
       "description": "Enable patch updates for kubernetes/kubernetes and k8s.io/kubernetes",
       "matchManagers": ["gomod", "custom.regex", "dockerfile"],
       "matchPackageNames": ["kubernetes/kubernetes", "k8s.io/kubernetes"],
-      "allowedVersions": "<1.37",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
@@ -120,7 +116,6 @@
         "!k8s.io/kube-openapi/**",
         "k8s.io/**"
       ],
-      "allowedVersions": "<0.37",
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,

--- a/rancher-2.15.json
+++ b/rancher-2.15.json
@@ -39,6 +39,8 @@
         "registry.opensuse.org/opensuse/bci/golang"
       ],
       "allowedVersions": "<1.27",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -46,6 +48,8 @@
       "matchDepTypes": ["!golang"],
       "matchDatasources": ["golang-version"],
       "allowedVersions": "<1.27",
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "enabled": true
     },
     {
@@ -63,6 +67,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -74,6 +80,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },
@@ -94,6 +102,8 @@
       "enabled": true,
       "groupName": "Kubernetes dependencies",
       "minimumGroupSize": 15,
+      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
+      "prPriority": 50,
       "commitMessageTopic": "Kubernetes dependencies",
       "commitMessageExtra": "to {{#if isSingleVersion}}{{newVersion}}{{else}}{{newValue}}{{/if}}"
     },


### PR DESCRIPTION
- Enable vulnerability updates for Go modules on Rancher release branches.
- Raise non-security Go and Kubernetes update priority to `50`.
- Preserve security update priority `100` and immediate PR creation.

## Goal

Go module vulnerability fixes were disabled on release branches, and important non-security Go/Kubernetes updates could wait behind lower-priority Renovate PRs. This keeps security fixes eligible while ensuring release dependency updates are processed earlier.