### PR TITLE
Prioritize non major updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -481,6 +481,12 @@
   ],
   "packageRules": [
     {
+      "description": "Prioritize non-GitHub Actions patch and minor updates before major updates",
+      "matchManagers": ["!github-actions"],
+      "matchUpdateTypes": ["major"],
+      "prPriority": -1
+    },
+    {
       "description": "Disable automerge for patch and minor updates",
       "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
       "matchUpdateTypes": ["patch", "minor"],

--- a/default.json
+++ b/default.json
@@ -96,7 +96,7 @@
       ],
       "description": "Track untagged Rancher CI container images in GitHub Actions workflows",
       "matchStrings": [
-        "(?<indentation>[ \\t]*)container:\\s+(?<depName>ghcr\\.io/rancher/ci-image/[a-z0-9_.-]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?<lineEnding>[ \\t]*(?:#.*)?(?:\\r?\\n|$))"
+        "(?<indentation>[ \\t]*)container:\\s+(?<depName>ghcr\\.io/rancher/ci-image/[a-z0-9_.-]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?(?<lineEnding>[ \\t]*(?:#[^\\r\\n]*)?(?:\\r?\\n|$))"
       ],
       "currentValueTemplate": "latest",
       "autoReplaceStringTemplate": "{{{indentation}}}container: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}{{{lineEnding}}}",


### PR DESCRIPTION
- Preserve targeted version comments when Renovate updates Rancher CI image digests - should fix the issue in the following [pr](https://github.com/rancher/rancher/pull/56791).
- Deprioritize major updates for non-GitHub Actions dependencies to make sure more relevant updates are pushed before.
- Keep GitHub Actions major updates at normal priority because for them major updates are more common and has usually no disadvantage to bump them.