### PR TITLE
Remove shared automerge disables

### DIFF
--- a/default.json
+++ b/default.json
@@ -487,18 +487,6 @@
       "prPriority": -1
     },
     {
-      "description": "Disable automerge for patch and minor updates",
-      "matchJsonata": ["$not($exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert))"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": false
-    },
-    {
-      "description": "Disable automerge for security updates",
-      "matchJsonata": ["$exists(vulnerabilityFixVersion) or $exists(isVulnerabilityAlert)"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": false
-    },
-    {
       "description": "Create a grouped PR to pin GitHub Actions digests",
       "groupName": "Pin GitHub Actions",
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
Leave automerge policy to consumer repository configurations.

Without it the repo owner has to enable automerge manually for each supported branch instead of with two rules.